### PR TITLE
bugfix inner_tag should be copied

### DIFF
--- a/invenio_records_lom/resources/serializers/__init__.py
+++ b/invenio_records_lom/resources/serializers/__init__.py
@@ -6,6 +6,7 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Serializers turning records into html-template-insertable dicts."""
+from copy import deepcopy
 
 from flask_resources.serializers import MarshmallowJSONSerializer
 from invenio_rdm_records.resources.serializers import UIJSONSerializer
@@ -103,8 +104,9 @@ class LOMToLOMXMLSerializer:
                     self.build(lst, parent_tag, self.element_maker(key.lower()))
         elif isinstance(jsn, list):
             for item in jsn:
-                self.build(item, inner_tag)
-                parent_tag.append(inner_tag)
+                local_tag = deepcopy(inner_tag)
+                self.build(item, local_tag)
+                parent_tag.append(local_tag)
         elif isinstance(jsn, str):
             parent_tag.text = jsn
         elif isinstance(jsn, int):


### PR DESCRIPTION
otherwise an json array is not mapped correct to xml.
before:
<inner_tag>
  <a></a>
  <a></a>
</inner_tag>
now:
<inner_tag>
  <a></a>
</inner_tag>
<inner_tag>
  <a></a>
</inner_tag>
