### PR TITLE
add pylint

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,9 +43,9 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"invenio-records-lom"
-copyright = u"2020, Graz University of Technology"
-author = u"Graz University of Technology"
+project = "invenio-records-lom"
+copyright = "2020, Graz University of Technology"
+author = "Graz University of Technology"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -106,7 +106,7 @@ nitpick_ignore = [("py:class", "flask.app.Flask")]
 html_theme = "alabaster"
 
 html_theme_options = {
-    "description": "invenio data model for Learning object metadata",
+    "description": "Invenio data model for Learning Object Metadata.",
     "github_user": "tu-graz-library",
     "github_repo": "invenio-records-lom",
     "github_button": False,
@@ -241,8 +241,8 @@ latex_documents = [
     (
         master_doc,
         "invenio-records-lom.tex",
-        u"invenio-records-lom Documentation",
-        u"Graz University of Technology",
+        "invenio-records-lom Documentation",
+        "Graz University of Technology",
         "manual",
     ),
 ]
@@ -276,7 +276,7 @@ man_pages = [
     (
         master_doc,
         "invenio-records-lom",
-        u"invenio-records-lom Documentation",
+        "invenio-records-lom Documentation",
         [author],
         1,
     )
@@ -295,7 +295,7 @@ texinfo_documents = [
     (
         master_doc,
         "invenio-records-lom",
-        u"invenio-records-lom Documentation",
+        "invenio-records-lom Documentation",
         author,
         "invenio-records-lom",
         "invenio data model for Learning object metadata",

--- a/invenio_records_lom/cli.py
+++ b/invenio_records_lom/cli.py
@@ -18,7 +18,6 @@ from .proxies import current_records_lom
 @click.group()
 def lom():
     """CLI-group for "invenio lom" commands."""
-    pass
 
 
 @lom.command("rebuild-index")
@@ -47,6 +46,6 @@ def rebuild_index():
 def demo(number, seed):
     """Publish `number` fake LOM records to the database, for demo purposes."""
     click.secho(f"Creating {number} LOM demo records", fg="green")
-    for lom in publish_fake_records(number, seed):
+    for __ in publish_fake_records(number, seed):
         pass
     click.secho("Published fake LOM records to the database!", fg="green")

--- a/invenio_records_lom/ext.py
+++ b/invenio_records_lom/ext.py
@@ -19,7 +19,7 @@ from .services import (
 )
 
 
-class InvenioRecordsLOM(object):
+class InvenioRecordsLOM:
     """invenio-records-lom extension."""
 
     def __init__(self, app=None):
@@ -48,7 +48,7 @@ class InvenioRecordsLOM(object):
         record_service_config = LOMRecordServiceConfig.build(app)
         file_service_config = LOMRecordFilesServiceConfig.build(app)
         draft_files_config = LOMDraftFilesServiceConfig.build(app)
-
+        # pylint: disable-next=attribute-defined-outside-init
         self.records_service = LOMRecordService(
             config=record_service_config,
             files_service=FileService(file_service_config),
@@ -56,8 +56,9 @@ class InvenioRecordsLOM(object):
             pids_service=PIDsService(record_service_config, PIDManager),
         )
 
-    def init_resources(self, app):
+    def init_resources(self, app):  # pylint: disable=unused-argument
         """Initialize resouces."""
+        # pylint: disable-next=attribute-defined-outside-init
         self.records_resource = LOMRecordResource(
             LOMRecordResourceConfig,
             self.records_service,

--- a/invenio_records_lom/fixtures/demo.py
+++ b/invenio_records_lom/fixtures/demo.py
@@ -23,7 +23,7 @@ from ..proxies import current_records_lom
 # functions for LOM datatypes
 #
 def langstringify(fake: Faker, text: str, lang: str = "") -> dict:
-    """Wraps `text` in a dict, emulating LOMv1.0-standard LangString-objects.
+    """Wraps `text` in a dict, emulating LOMv1.0 LangString-objects.
 
     If `lang` is given and None, no "lang"-key is added to the returned dict.
     If `lang` is given and truthy, its value is used for the "lang"-key.
@@ -37,7 +37,7 @@ def langstringify(fake: Faker, text: str, lang: str = "") -> dict:
 
 
 def vocabularify(fake: Faker, choices: list) -> dict:
-    """Randomly draw a choice from `choices`, then wrap that choice in a dict, emulating LOMv1.0-standard Vocabulary-objects."""
+    """Randomly draw a choice from `choices`, then wrap it in a dict, emulating LOMv1.0 Vocabulary-objects."""
     return {
         "source": langstringify(fake, "LOMv1.0", lang="x-none"),
         "value": langstringify(fake, fake.random.choice(choices), lang="x-none"),
@@ -45,7 +45,7 @@ def vocabularify(fake: Faker, choices: list) -> dict:
 
 
 def create_fake_datetime(fake: Faker) -> dict:
-    """Create a fake datetime dict, as per LOMv1.0-standard Datetime-object-specification."""
+    """Create a fake datetime dict, as per LOMv1.0 Datetime-object-specification."""
     pattern = fake.random.choice(["YMDhmsTZD", "YMDhms", "YMD", "Y"])
     if pattern == "Y":
         datetime = fake.year()
@@ -78,7 +78,7 @@ def create_fake_vcard(fake: Faker) -> str:
 # functions for elements that are part of more than one category
 #
 def create_fake_language(fake: Faker) -> str:
-    """Create a fake language-code, as required for "language"-keys by LOMv1.0-standard."""
+    """Create a fake language-code, as required for "language"-keys by LOMv1.0."""
     language_codes = [
         "EN",
         "en-us",
@@ -89,7 +89,7 @@ def create_fake_language(fake: Faker) -> str:
 
 
 def create_fake_identifier(fake: Faker) -> dict:
-    """Create a fake "identifier"-element, compatible with LOMv1.0-standard."""
+    """Create a fake "identifier"-element, compatible with LOMv1.0."""
     catalog = fake.random.choice(["URL", "ISBN"])
     if catalog == "URL":
         entry = fake.uri()
@@ -105,7 +105,7 @@ def create_fake_identifier(fake: Faker) -> dict:
 
 
 def create_fake_contribute(fake: Faker, roles: list) -> dict:
-    """Create a fake "contribute"-element, compatible with LOMv1.0-standard."""
+    """Create a fake "contribute"-element, compatible with LOMv1.0."""
     return {
         "role": vocabularify(fake, roles),
         "entity": create_fake_vcard(fake),
@@ -117,7 +117,7 @@ def create_fake_contribute(fake: Faker, roles: list) -> dict:
 # functions for categories or used by only one category
 #
 def create_fake_general(fake: Faker) -> dict:
-    """Create a fake "general"-element, compatible with LOMv1.0-standard."""
+    """Create a fake "general"-element, compatible with LOMv1.0."""
     structures = ["atomic", "collection", "networked", "hierarchical", "linear"]
     aggregationLevels = ["1", "2", "3", "4"]
 
@@ -134,7 +134,7 @@ def create_fake_general(fake: Faker) -> dict:
 
 
 def create_fake_lifecycle(fake: Faker) -> dict:
-    """Create a fake "lifeCycle"-element, compatible with LOMv1.0-standard."""
+    """Create a fake "lifeCycle"-element, compatible with LOMv1.0."""
     roles = [
         "author",
         "publisher",
@@ -165,7 +165,7 @@ def create_fake_lifecycle(fake: Faker) -> dict:
 
 
 def create_fake_metametadata(fake: Faker) -> dict:
-    """Create a fake "metaMetadata"-element, compatible with LOMv1.0-standard."""
+    """Create a fake "metaMetadata"-element, compatible with LOMv1.0."""
     roles = ["creator", "validator"]
     return {
         "identifier": [create_fake_identifier(fake) for __ in range(2)],
@@ -190,14 +190,14 @@ def create_fake_technical(fake: Faker) -> dict:
 
 
 def create_fake_requirement(fake: Faker) -> dict:
-    """Create a fake "requirement"-element, compatible with LOMv1.0-standard."""
+    """Create a fake "requirement"-element, compatible with LOMv1.0."""
     return {
         "orComposite": [create_fake_orcomposite(fake) for __ in range(2)],
     }
 
 
 def create_fake_orcomposite(fake: Faker) -> dict:
-    """Create a fake "orComposite"-element, compatible with LOMv1.0-standard."""
+    """Create a fake "orComposite"-element, compatible with LOMv1.0."""
     type_ = fake.random.choice(["operating system", "browser"])
     if type_ == "operating system":
         requirement_names = [
@@ -226,7 +226,7 @@ def create_fake_orcomposite(fake: Faker) -> dict:
 
 
 def create_fake_educational(fake: Faker) -> dict:
-    """Create a fake "educational"-element, compatible with LOMv1.0-standard."""
+    """Create a fake "educational"-element, compatible with LOMv1.0."""
     interactivity_types = ["active", "expositive", "mixed"]
     levels = ["very low", "low", "medium", "high", "very high"]
     difficulties = ["very easy", "easy", "medium", "difficult", "very difficult"]
@@ -251,7 +251,7 @@ def create_fake_educational(fake: Faker) -> dict:
 
 
 def create_fake_learningresourcetype(fake: Faker) -> dict:
-    """Create a fake "learningResourceType"-element, compatible with LOM-UIBK-standard."""
+    """Create a fake "learningResourceType"-element, compatible with LOM-UIBK."""
     url_endings = [
         "application",
         "assessment",
@@ -290,7 +290,7 @@ def create_fake_learningresourcetype(fake: Faker) -> dict:
 
 
 def create_fake_rights(fake: Faker) -> dict:
-    """Create a fake "rights"-element, compatible with LOMv1.0-standard."""
+    """Create a fake "rights"-element, compatible with LOMv1.0."""
     return {
         "cost": vocabularify(fake, ["yes", "no"]),
         "copyrightAndOtherRestrictions": vocabularify(fake, ["yes", "no"]),
@@ -299,7 +299,7 @@ def create_fake_rights(fake: Faker) -> dict:
 
 
 def create_fake_relation(fake: Faker) -> dict:
-    """Create a fake "relation"-element, compatible with LOMv1.0-standard."""
+    """Create a fake "relation"-element, compatible with LOMv1.0."""
     kinds = [
         "ispartof",
         "haspart",
@@ -325,7 +325,7 @@ def create_fake_relation(fake: Faker) -> dict:
 
 
 def create_fake_annotation(fake: Faker) -> dict:
-    """Create a fake "annotation"-element, compatible with LOMv1.0-standard."""
+    """Create a fake "annotation"-element, compatible with LOMv1.0."""
     return {
         "entity": create_fake_vcard(fake),
         "date": create_fake_datetime(fake),
@@ -334,7 +334,7 @@ def create_fake_annotation(fake: Faker) -> dict:
 
 
 def create_fake_classification(fake: Faker) -> dict:
-    """Create a fake "classification"-element, compatible with LOMv1.0-standard."""
+    """Create a fake "classification"-element, compatible with LOMv1.0."""
     purposes = [
         "discipline",
         "idea",
@@ -356,7 +356,7 @@ def create_fake_classification(fake: Faker) -> dict:
 
 
 def create_fake_taxonpath(fake: Faker) -> dict:
-    """Create a fake "taxonPath"-element, compatible with LOMv1.0-standard."""
+    """Create a fake "taxonPath"-element, compatible with LOMv1.0."""
     return {
         "source": langstringify(fake, fake.word(), lang="x-none"),
         "taxon": [create_fake_taxon(fake) for __ in range(2)],
@@ -364,7 +364,7 @@ def create_fake_taxonpath(fake: Faker) -> dict:
 
 
 def create_fake_taxon(fake: Faker) -> dict:
-    """Create a fake "taxon"-element, compatible with LOMv1.0-standard."""
+    """Create a fake "taxon"-element, compatible with LOMv1.0."""
     lang = fake.random.choice([None, create_fake_language(fake)])
     return {
         "id": fake.lexify(
@@ -379,7 +379,7 @@ def create_fake_taxon(fake: Faker) -> dict:
 # functions for creating LOMv1.0-fakes
 #
 def create_fake_metadata(fake: Faker) -> dict:
-    """Create a fake json-representation of a "lom"-element, compatible with LOMv1.0-standard."""
+    """Create a fake json-representation of a "lom"-element, compatible with LOMv1.0."""
     data_to_use = {
         "general": create_fake_general(fake),
         "lifeCycle": create_fake_lifecycle(fake),
@@ -491,7 +491,7 @@ def create_then_publish(fake: Faker, data: dict, create_fake_files: bool = False
 def inject_relation(data: dict, kind: str, pid: str):
     """Inject relation of kind `kind` into `data` under entry `pid`.
 
-    `data` is a json-representation of data, compatible with LOMv1.0-standard.
+    `data` is a json-representation of data, compatible with LOMv1.0.
     `kind` is a kind, as in LOMv1.0's `relation`-group.
     `pid` is entry, as in LOMv1.0's `relation.resource.identifier` category.
     """
@@ -539,23 +539,23 @@ def link_up(whole_id: str, part_id: str):
 def publish_fake_record(fake: Faker):
     """Enter fake records into the SQL-database."""
     course_data = create_fake_data(fake, resource_type="course")
-    course_service_item = create_then_publish(fake=fake, data=course_data)
+    course_item = create_then_publish(fake=fake, data=course_data)
 
     for __ in range(2):
         unit_data = create_fake_data(fake, resource_type="unit")
-        unit_service_item = create_then_publish(fake=fake, data=unit_data)
-        link_up(whole_id=course_service_item.id, part_id=unit_service_item.id)
+        unit_item = create_then_publish(fake=fake, data=unit_data)
+        link_up(whole_id=course_item.id, part_id=unit_item.id)
 
         for __ in range(2):
             file_data = create_fake_data(fake, resource_type="file", files_enabled=True)
-            file_service_item = create_then_publish(
+            file_item = create_then_publish(
                 fake=fake, data=file_data, create_fake_files=True
             )
-            link_up(whole_id=unit_service_item.id, part_id=file_service_item.id)
+            link_up(whole_id=unit_item.id, part_id=file_item.id)
 
 
 def publish_fake_records(number: int, seed: int = 42) -> list:
-    """Create `number` jsons adhering to LOMv1.0-standard, using `seed` as RNG-seed."""
+    """Create `number` jsons adhering to LOM-standard, using `seed` as RNG-seed."""
     fake = Faker()
     Faker.seed(seed)
 

--- a/invenio_records_lom/oai.py
+++ b/invenio_records_lom/oai.py
@@ -16,7 +16,7 @@ from .proxies import current_records_lom
 from .resources.serializers import LOMToLOMXMLSerializer
 
 
-def lom_etree(pid, record):
+def lom_etree(pid, record):  # pylint: disable=unused-argument
     """Get LOM XML for OAI-PMH."""
     return LOMToLOMXMLSerializer(
         metadata=record["_source"]["metadata"],
@@ -34,8 +34,8 @@ def getrecord_fetcher(record_id):
 
     try:
         result = current_records_lom.records_service.read(g.identity, lomid.pid_value)
-    except PermissionDeniedError:
+    except PermissionDeniedError as error:
         # if it is a restricted record.
-        raise PIDDoesNotExistError("lomid", None)
+        raise PIDDoesNotExistError("lomid", None) from error
 
     return result.to_dict()

--- a/invenio_records_lom/records/__init__.py
+++ b/invenio_records_lom/records/__init__.py
@@ -14,9 +14,9 @@ which - in turn - is based on the DataCite data model.
 from .api import LOMDraft, LOMFileDraft, LOMFileRecord, LOMParent, LOMRecord
 
 __all__ = (
-    LOMDraft,
-    LOMFileDraft,
-    LOMFileRecord,
-    LOMParent,
-    LOMRecord,
+    "LOMDraft",
+    "LOMFileDraft",
+    "LOMFileRecord",
+    "LOMParent",
+    "LOMRecord",
 )

--- a/invenio_records_lom/records/api.py
+++ b/invenio_records_lom/records/api.py
@@ -120,32 +120,30 @@ class RelationsMeta(type):
     Delays assigning to `.relations`' `pid_field` until class is already created.
     """
 
-    def __new__(mcs, name, bases, attrs):
+    def __new__(cls, name, bases, attrs):
         """Create and return a new class with `.relations`-attribute."""
-        cls = super().__new__(mcs, name, bases, attrs)
+        new_cls = super().__new__(cls, name, bases, attrs)
         relations = RelationsField(
             wholes=PIDLOMRelation(
                 source="LOMv1.0",
                 value="ispartof",
-                pid_field=cls.pid,
+                pid_field=new_cls.pid,
                 cache_key="lom-wholes",
             ),
             parts=PIDLOMRelation(
                 source="LOMv1.0",
                 value="haspart",
-                pid_field=cls.pid,
+                pid_field=new_cls.pid,
                 cache_key="lom-parts",
             ),
         )
-        relations.__set_name__(cls, "relations")
-        cls.relations = relations
-        return cls
+        relations.__set_name__(new_cls, "relations")
+        new_cls.relations = relations
+        return new_cls
 
 
 class LOMRecordMeta(type(Record), RelationsMeta):
     """Meta-Class for LOM-Records."""
-
-    pass
 
 
 class LOMRecord(Record, metaclass=LOMRecordMeta):

--- a/invenio_records_lom/records/systemfields/__init__.py
+++ b/invenio_records_lom/records/systemfields/__init__.py
@@ -22,11 +22,11 @@ from .relations import PIDLOMRelation
 from .resolver import LOMResolver
 
 __all__ = (
-    LOMDraftRecordIdProvider,
-    LOMPIDFieldContext,
-    LOMRecordIdProvider,
-    LOMResolver,
-    ParentRecordAccessField,
-    PIDLOMRelation,
-    RecordAccessField,
+    "LOMDraftRecordIdProvider",
+    "LOMPIDFieldContext",
+    "LOMRecordIdProvider",
+    "LOMResolver",
+    "ParentRecordAccessField",
+    "PIDLOMRelation",
+    "RecordAccessField",
 )

--- a/invenio_records_lom/records/systemfields/results.py
+++ b/invenio_records_lom/records/systemfields/results.py
@@ -21,7 +21,7 @@ class RelationLOMResult(RelationResult):
             f"{self.__class__.__qualname__}.__call__ is not implemented yet"
         )
 
-    def _lookup_id(self, data):
+    def _lookup_id(self):
         raise NotImplementedError(
             f"{self.__class__.__qualname__}._lookup_id is not implemented yet"
         )
@@ -30,7 +30,6 @@ class RelationLOMResult(RelationResult):
         """Validate the field."""
         # this gets called on service.publish()->record.commit()->extension.pre_commit()
         # TODO: raise when json is ill-formed
-        pass
 
     def _apply_items(self, func: callable, attrs: dict = None):
         relations = self.record.get("metadata", {}).get("relation", [])

--- a/invenio_records_lom/resources/resources.py
+++ b/invenio_records_lom/resources/resources.py
@@ -17,11 +17,11 @@ class LOMRecordResource(RecordResource):
     def create_url_rules(self):
         """Create the URL rules for the record resource."""
 
-        def p(route):
+        def prefix(route_str):
             """Prefix a route with `self.config.prefix`."""
-            return f"{self.config.url_prefix}{route}"
+            return f"{self.config.url_prefix}{route_str}"
 
         routes = self.config.routes
         return [
-            route("GET", p(routes["item"]), self.read),
+            route("GET", prefix(routes["item"]), self.read),
         ]

--- a/invenio_records_lom/resources/serializers/__init__.py
+++ b/invenio_records_lom/resources/serializers/__init__.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 
 from flask_resources.serializers import MarshmallowJSONSerializer
 from invenio_rdm_records.resources.serializers import UIJSONSerializer
-from lxml.builder import ElementMaker
+from lxml.builder import ElementMaker  # pylint: disable=no-name-in-module
 
 from .schemas import LOMToDataCite44Schema, LOMUIObjectSchema
 

--- a/invenio_records_lom/resources/serializers/schemas.py
+++ b/invenio_records_lom/resources/serializers/schemas.py
@@ -51,11 +51,11 @@ class Contributors(fields.Field):
     def _serialize(self, value, attr, obj, **kwargs):
         """Serialize."""
         contributors = []
-        for obj in value:
+        for sub_obj in value:
             contributors.append(
                 {
-                    "fullname": obj["entity"],
-                    "role": get_text(obj["role"]["value"]),
+                    "fullname": sub_obj["entity"],
+                    "role": get_text(sub_obj["role"]["value"]),
                 }
             )
         return contributors
@@ -137,6 +137,8 @@ class LOMUIObjectSchema(Schema):
 
     rights = Rights(attribute="metadata.rights")
 
+    is_draft = fields.Boolean(attribute="is_draft")
+
 
 class LOMToDataCite44Schema(Schema):
     """Schema for conversion from LOM to DataCite-REST JSON 4.4."""
@@ -205,7 +207,7 @@ class LOMToDataCite44Schema(Schema):
             return []
         return [{"title": get_text(title), "lang": get_lang(title)}]
 
-    def get_publisher(self, obj: LOMRecord):
+    def get_publisher(self, obj: LOMRecord):  # pylint: disable=unused-argument
         """Get publisher."""
         return current_app.config["LOM_PUBLISHER"]
 
@@ -265,8 +267,7 @@ class LOMToDataCite44Schema(Schema):
         languages = [lang for lang in languages if lang != "none"]
         if languages:
             return languages[0]
-        else:
-            return missing
+        return missing
 
     def get_relatedIdentifiers(self, obj: LOMRecord):
         """Get list of relatedIdentifier-dicts."""
@@ -310,8 +311,7 @@ class LOMToDataCite44Schema(Schema):
         """Get list of sizes."""
         if size := obj["metadata"].get("technical", {}).get("size"):
             return [str(size)]
-        else:
-            return missing
+        return missing
 
     def get_formats(self, obj: LOMRecord):
         """Get list of formats."""
@@ -327,5 +327,4 @@ class LOMToDataCite44Schema(Schema):
         rights = obj["metadata"].get("rights", {})
         if description_langstring := rights.get("description"):
             return [{"rights": get_text(description_langstring)}]
-        else:
-            return missing
+        return missing

--- a/invenio_records_lom/services/components.py
+++ b/invenio_records_lom/services/components.py
@@ -26,30 +26,35 @@ class ResourceTypeComponent(ServiceComponent):
 
     new_version_skip_fields = ["publication_date", "version"]
 
+    # pylint: disable-next=unused-argument
     def create(
         self, identity: Identity, data: dict = None, record: Record = None, **kwargs
     ):
         """Inject parsed resource_type to the record."""
         record.resource_type = data.get("resource_type", {})
 
+    # pylint: disable-next=unused-argument, arguments-differ
     def update_draft(
         self, identity: Identity, data: dict = None, record: Record = None, **kwargs
     ):
         """Inject parsed resource_type to the record."""
         record.resource_type = data.get("resource_type", {})
 
+    # pylint: disable-next=unused-argument
     def publish(
         self, identity: Identity, draft: Record = None, record: Record = None, **kwargs
     ):
         """Update draft resource_type."""
         record.resource_type = draft.get("resource_type", {})
 
+    # pylint: disable-next=unused-argument
     def edit(
         self, identity: Identity, draft: Record = None, record: Record = None, **kwargs
     ):
         """Update draft resource_type."""
         draft.resource_type = record.get("resource_type", {})
 
+    # pylint: disable-next=unused-argument
     def new_version(
         self, identity: Identity, draft: Record = None, record: Record = None, **kwargs
     ):

--- a/invenio_records_lom/services/services.py
+++ b/invenio_records_lom/services/services.py
@@ -10,7 +10,6 @@
 from invenio_rdm_records.services import RDMRecordService
 
 
+# pylint: disable-next=abstract-method
 class LOMRecordService(RDMRecordService):
     """RecordService configured for LOM-use."""
-
-    pass

--- a/invenio_records_lom/ui/records/errors.py
+++ b/invenio_records_lom/ui/records/errors.py
@@ -21,17 +21,17 @@ from flask import current_app, render_template
 from flask_login import current_user
 
 
-def not_found_error(error: Exception):
+def not_found_error(error: Exception):  # pylint: disable=unused-argument
     """Handler for 'Not Found' errors."""
     return render_template(current_app.config["THEME_404_TEMPLATE"]), 404
 
 
-def record_tombstone_error(error: Exception):
+def record_tombstone_error(error: Exception):  # pylint: disable=unused-argument
     """Tombstone page."""
     return render_template("invenio_app_rdm/records/tombstone.html"), 410
 
 
-def record_permission_denied_error(error: Exception):
+def record_permission_denied_error(error: Exception):  # pylint: disable=unused-argument
     """Handle permission denier error on record views."""
     if not current_user.is_authenticated:
         # trigger the flask-login unauthorized handler

--- a/invenio_records_lom/ui/records/records.py
+++ b/invenio_records_lom/ui/records/records.py
@@ -73,7 +73,7 @@ class PreviewFile:
 
     def open(self):
         """Open the file."""
-        return self.file._file.file.storage().open()
+        return self.file._file.file.storage().open()  # pylint: disable=protected-access
 
 
 #
@@ -92,7 +92,7 @@ def record_detail(
     files_dict = {} if files is None else files.to_dict()
     record_ui = LOMUIJSONSerializer().serialize_object_to_dict(record.to_dict())
 
-    if is_preview and record._record.is_draft:
+    if is_preview and record_ui["is_draft"]:
         abort(404)
 
     return render_template(
@@ -104,7 +104,7 @@ def record_detail(
             ["edit", "new_version", "manage", "update_draft", "read_files"]
         ),
         is_preview=is_preview,
-        is_draft=record._record.is_draft,
+        is_draft=record_ui["is_draft"],
     )
 
 
@@ -113,7 +113,7 @@ def record_detail(
 def record_export(
     record: RecordItem = None,
     export_format: str = None,
-    pid_value: str = None,
+    pid_value: str = None,  # pylint: disable=unused-argument
     is_preview: bool = False,
 ):
     """Export view for LOM records."""
@@ -135,7 +135,7 @@ def record_export(
         record=LOMUIJSONSerializer().serialize_object_to_dict(record.to_dict()),
         permissions=record.has_permissions_to(["update_draft"]),
         is_preview=is_preview,
-        is_draft=record._record.is_draft,
+        is_draft=record._record.is_draft,  # pylint: disable=protected-access
     )
 
 
@@ -143,9 +143,9 @@ def record_export(
 @pass_record_or_draft
 @pass_file_metadata
 def record_file_preview(
-    record: RecordItem = None,
+    record: RecordItem = None,  # pylint: disable=unused-argument
     pid_value: str = None,
-    pid_type: str = "recid",
+    pid_type: str = "recid",  # pylint: disable=unused-argument
     file_metadata: FileItem = None,
     is_preview: bool = False,
     **kwargs,
@@ -174,9 +174,9 @@ def record_file_preview(
 @pass_file_item
 def record_file_download(
     file_item: FileItem = None,
-    pid_value: str = None,
-    is_preview: bool = False,
-    **kwargs,
+    pid_value: str = None,  # pylint: disable=unused-argument
+    is_preview: bool = False,  # pylint: disable=unused-argument
+    **kwargs,  # pylint: disable=unused-argument
 ):
     """Download a file from a record."""
     download = bool(request.args.get("download"))
@@ -184,12 +184,18 @@ def record_file_download(
 
 
 @pass_record_latest
-def record_latest(record: RecordItem = None, **kwargs):
+def record_latest(
+    record: RecordItem = None,
+    **kwargs,  # pylint: disable=unused-argument
+):
     """Redirect to record's landing page."""
     return redirect(record["links"]["self_html"], code=301)
 
 
 @pass_record_from_pid
-def record_from_pid(record: RecordItem = None, **kwargs):
+def record_from_pid(
+    record: RecordItem = None,
+    **kwargs,  # pylint: disable=unused-argument
+):
     """Redirect to record's landing page."""
     return redirect(record["links"]["self_html"], code=301)

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ tests =
     pytest-isort>=3.0.0
     pytest-mock>=1.6.0
     pytest-pydocstyle>=2.2.0
+    pytest-pylint>=0.18.0
     Sphinx>=4.4.0
     sphinx-autodoc-typehints>=1.10.3
 elasticsearch7 =
@@ -123,11 +124,13 @@ ignore = E501
 [pydocstyle]
 add_ignore = D401
 
+[pylint.messages_control]
+disable = fixme, invalid-name, line-too-long, no-member, no-self-use, too-few-public-methods, too-many-arguments
 
 [tool:isort]
 profile = black
 
 [tool:pytest]
-addopts = --bandit --black --flake8 --isort --pydocstyle --cov=invenio_records_lom --cov-report=term-missing tests invenio_records_lom --doctest-glob="*.rst" --doctest-modules
+addopts = --bandit --black --flake8 --isort --pydocstyle --pylint --cov=invenio_records_lom --cov-report=term-missing tests invenio_records_lom --doctest-glob="*.rst" --doctest-modules
 testpaths = tests invenio_records_lom
 live_server_scope = module

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,12 +19,13 @@ from faker import Faker
 from flask_principal import Identity, UserNeed
 from invenio_access.permissions import any_user, system_process
 from invenio_app.factory import create_app as invenio_create_app
+from invenio_files_rest.models import Location
 
 from invenio_records_lom.fixtures import create_fake_data
 
 
 @pytest.fixture(scope="module")
-def app_config(app_config):
+def app_config(app_config):  # pylint: disable=redefined-outer-name
     """Override pytest-invenio app_config-fixture."""
     # Enable DOI minting...
     app_config["DATACITE_ENABLED"] = True
@@ -51,8 +52,6 @@ def cli_location(db):
 
     Adapted to work with `<Flask-obj>.test_cli_runner`.
     """
-    from invenio_files_rest.models import Location
-
     uri = tempfile.mkdtemp()
     location_obj = Location(name="pytest-location", uri=uri, default=True)
 
@@ -77,7 +76,7 @@ def identity():
 
 
 @pytest.fixture(scope="function")
-def service(base_app, location):
+def service(base_app, location):  # pylint: disable=unused-argument
     """Service fixture."""
     return base_app.extensions["invenio-records-lom"].records_service
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,13 +11,17 @@ from invenio_records_lom.cli import lom
 
 
 def test_discover_lom_cli_command(base_app):
+    """Test whether `invenio lom`-CLI-command-group can be found."""
     runner = base_app.test_cli_runner()
     result = runner.invoke(lom)
     assert result.exit_code == 0
 
 
-def test_create_demo_metadata(base_app, cli_location):
-    """Test "invenio lom demo"."""
+def test_create_demo_metadata(
+    base_app,
+    cli_location,  # pylint: disable=unused-argument
+):
+    """Test `invenio lom demo`."""
     runner = base_app.test_cli_runner()
     result = runner.invoke(
         lom,

--- a/tests/test_invenio_records_lom.py
+++ b/tests/test_invenio_records_lom.py
@@ -9,13 +9,11 @@
 
 from flask import Flask
 
-from invenio_records_lom import InvenioRecordsLOM
+from invenio_records_lom import InvenioRecordsLOM, __version__
 
 
 def test_version():
     """Test version import."""
-    from invenio_records_lom import __version__
-
     assert __version__
 
 

--- a/tests/test_pids_service.py
+++ b/tests/test_pids_service.py
@@ -15,6 +15,7 @@ from invenio_records_lom.resources.serializers import LOMToDataCite44Serializer
 from invenio_records_lom.services.tasks import register_or_update_pid
 
 
+# pylint: disable-next=unused-argument
 def test_resolve_pid(service, db, identity, full_lom_metadata):
     """Resolve a PID."""
     draft = service.create(identity=identity, data=full_lom_metadata)
@@ -29,24 +30,27 @@ def test_resolve_pid(service, db, identity, full_lom_metadata):
 
 def test_resolve_nonexisting_pid(service, identity):
     """Attempt to resolve a non-existing pid."""
-    fake_doi = "10,4321/client.12345-invalid"
+    fake_doi = "10.4321/client.12345-invalid"
 
     with pytest.raises(PIDDoesNotExistError):
         service.pids.resolve(identity=identity, id_=fake_doi, scheme="doi")
 
 
+# pylint: disable-next=unused-argument
 def test_reserve_pid(service, db, identity, full_lom_metadata):
     """Reserve a new pid."""
     draft = service.create(identity=identity, data=full_lom_metadata)
     draft = service.pids.create(identity=identity, id_=draft.id, scheme="doi")
     doi = draft["pids"]["doi"]["identifier"]
 
+    # pylint: disable-next=protected-access
     provider = service.pids.pid_manager._get_provider("doi", "datacite")
     pid = provider.get(pid_value=doi)
 
     assert pid.status == PIDStatus.NEW
 
 
+# pylint: disable-next=unused-argument
 def test_datacite_schema(service, db, full_lom_metadata):
     """Dump a LOM-object with LOMSerializer."""
     datacite_data = LOMToDataCite44Serializer().dump_one(full_lom_metadata)
@@ -61,12 +65,12 @@ def test_datacite_schema(service, db, full_lom_metadata):
     assert all(key in datacite_data for key in mandatory_keys)
 
 
+# pylint: disable-next=unused-argument
 def test_register_pid(service, db, identity, full_lom_metadata, mocker):
     """Register a pid."""
 
-    def public_doi(self, metadata, url, doi):
+    def public_doi(self, metadata, url, doi):  # pylint: disable=unused-argument
         """Mock doi publication."""
-        pass
 
     mocker.patch(
         "invenio_rdm_records.services.pids.providers.datacite.DataCiteRESTClient.public_doi",
@@ -77,9 +81,11 @@ def test_register_pid(service, db, identity, full_lom_metadata, mocker):
     draft = service.pids.create(identity=identity, id_=draft.id, scheme="doi")
     doi = draft["pids"]["doi"]["identifier"]
 
+    # pylint: disable-next=protected-access
     provider = service.pids.pid_manager._get_provider("doi", "datacite")
     pid = provider.get(pid_value=doi)
 
+    # pylint: disable-next=protected-access
     record = service.record_cls.publish(draft._record)
     record.pids = {
         pid.pid_type: {

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -112,7 +112,7 @@ def test_create_draft(service, db, identity, access):
     "access",
     _ACCESS_CONFIGURATIONS,
 )
-def test_publish(service, db, identity, access):
+def test_publish(service, db, identity, access):  # pylint: disable=too-many-locals
     """Test publishing a record, then test database changes."""
     data = {
         "access": access,


### PR DESCRIPTION
use pylint from now on
includes various fixes suggested by pylint

notes:
- added `UISchema.is_draft` to forgo private access
- renamed argument-names to fit conventional names
- pylint won't find `lxml.Elementmaker` because it's a C-module
- changed method-signature to conform with parent-class's
- shortened names to keep within character-per-line limit