### PR TITLE
fix combined fixes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 Graz University of Technology.
+# Copyright (C) 2020-2022 Graz University of Technology.
 #
 # invenio-records-lom is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Sphinx configuration."""
+
+from datetime import datetime, timezone
 
 from invenio_records_lom import __version__
 
@@ -44,7 +46,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "invenio-records-lom"
-copyright = "2020, Graz University of Technology"
+copyright = f"{datetime.now(timezone.utc).year}, Graz University of Technology"
 author = "Graz University of Technology"
 
 # The version info for the project you're documenting, acts as replacement for
@@ -61,7 +63,7 @@ release = __version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
- language = None in Sphinx 5.0.0 should be set to "en"
- use datetime to set the current year in the documentation
