### PR TITLE
improve metadata-creation

### DIFF
--- a/invenio_records_lom/ext.py
+++ b/invenio_records_lom/ext.py
@@ -40,6 +40,16 @@ class InvenioRecordsLOM:
         Override configuration variables with the values in this package.
         """
         for k in dir(config):
+            if k == "LOM_PERSISTENT_IDENTIFIER_PROVIDERS":
+                app.config.setdefault("LOM_PERSISTENT_IDENTIFIER_PROVIDERS", [])
+                app.config["LOM_PERSISTENT_IDENTIFIER_PROVIDERS"].extend(
+                    getattr(config, k)
+                )
+
+            elif k == "LOM_PERSISTENT_IDENTIFIERS":
+                app.config.setdefault("LOM_PERSISTENT_IDENTIFIERS", {})
+                app.config["LOM_PERSISTENT_IDENTIFIERS"].update(getattr(config, k))
+
             if k.startswith("LOM_"):
                 app.config.setdefault(k, getattr(config, k))
 

--- a/invenio_records_lom/fixtures/demo.py
+++ b/invenio_records_lom/fixtures/demo.py
@@ -481,18 +481,10 @@ def create_then_publish(fake: Faker, data: dict, create_fake_files: bool = False
 
     # partially apply identity=system_identity
     create = partial(service.create, identity=system_identity)
-    update_draft = partial(service.update_draft, identity=system_identity)
     publish = partial(service.publish, identity=system_identity)
 
     # create
     draft_item = create(data=data)
-
-    # add repo-pid to the record's identifiers
-    draft_data = draft_item.to_dict()
-    draft_data["metadata"]["general"]["identifier"].append(
-        {"catalog": "repo-pid", "entry": langstringify(fake, draft_item.id)}
-    )
-    draft_item = update_draft(id_=draft_item.id, data=draft_data)
 
     if create_fake_files:
         attach_fake_files(fake, draft_item)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -66,12 +66,13 @@ def _pick_by_cls(iterable, cls, assert_unique=True):
     "access",
     _ACCESS_CONFIGURATIONS,
 )
-def test_create_draft(service, db, identity, access):
+def test_create_draft(service, db, identity, access):  # pylint: disable=too-many-locals
     """Test creating a draft, then test database changes."""
+    title_langstring = {"langstring": {"#text": "Test", "lang": "en"}}
     data = {
         "access": access,
         "files": {"enabled": False},
-        "metadata": {"general": {"title": {"string": "Test"}}},
+        "metadata": {"general": {"title": title_langstring}},
         "resource_type": "course",
     }
 
@@ -96,9 +97,17 @@ def test_create_draft(service, db, identity, access):
     assert new_versions_state.parent_id == new_parent.id
     assert new_draft.parent_id == new_parent.id
 
-    # test json
+    # test whether pid was added by service.create
     json = new_draft.json
     assert "metadata" in json
+    assert "general" in json["metadata"]
+    general = json["metadata"]["general"]
+    json_pid = general["identifier"][0]["entry"]["langstring"]["#text"]
+    assert json_pid == draft_pid.pid_value
+
+    # test json
+    # other than general.identifier, record's metadata should be identical to initial metadata
+    del general["identifier"]
     assert json["metadata"] == data["metadata"]
     assert "access" in json
     assert json["access"]["files"] == access["files"]
@@ -114,10 +123,11 @@ def test_create_draft(service, db, identity, access):
 )
 def test_publish(service, db, identity, access):  # pylint: disable=too-many-locals
     """Test publishing a record, then test database changes."""
+    title_langstring = {"langstring": {"#text": "Test", "lang": "en"}}
     data = {
         "access": access,
         "files": {"enabled": False},
-        "metadata": {"general": {"title": {"string": "Test"}}},
+        "metadata": {"general": {"title": title_langstring}},
         "resource_type": "course",
     }
 
@@ -148,9 +158,17 @@ def test_publish(service, db, identity, access):  # pylint: disable=too-many-loc
     assert new_draft.parent_id == new_parent.id
     assert new_record.parent_id == new_parent.id
 
-    # test json
+    # test whether pid was added by service.create
     json = new_record.json
     assert "metadata" in json
+    assert "general" in json["metadata"]
+    general = json["metadata"]["general"]
+    json_pid = general["identifier"][0]["entry"]["langstring"]["#text"]
+    assert json_pid == record_pid.pid_value
+
+    # test json
+    # other than general.identifier, record's metadata should be identical to initial metadata
+    del general["identifier"]
     assert json["metadata"] == data["metadata"]
     assert "access" in json
     assert json["access"]["files"] == access["files"]


### PR DESCRIPTION
- `service.create` now automatically adds repo-pid to metadata
- use the recommended importlib.resources for importing files
- use standardlib's `csv.reader` to read csv
- rename and rewrite `DotAccessWrapper.check` for clarity
- `LOMMetadata` now operates on jsons like the ones in the database
    (used to operate only on the `metadata`-attribute)
- `LOMMetadata.__init__` only wraps input (unchanged)
- `LOMMetadata.create` creates an object given its parameters (new)
- `LOMMetadata.append_*`-methods now don't duplicate data
    (this makes those methods idempotent)
- added `LOMMetadata.append_relation`