### PR TITLE
fix image-preview by implementing iiif-resource

### DIFF
--- a/invenio_records_lom/ext.py
+++ b/invenio_records_lom/ext.py
@@ -6,6 +6,8 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Flask extension for invenio-records-lom."""
+from invenio_rdm_records.resources import IIIFResource
+from invenio_rdm_records.services import IIIFService
 from invenio_rdm_records.services.pids import PIDManager, PIDsService
 from invenio_records_resources.resources import FileResource
 from invenio_records_resources.services import FileService
@@ -13,6 +15,7 @@ from invenio_records_resources.services import FileService
 from . import config
 from .resources import (
     LOMDraftFilesResourceConfig,
+    LOMIIIFResourceConfig,
     LOMRecordFilesResourceConfig,
     LOMRecordResource,
     LOMRecordResourceConfig,
@@ -72,12 +75,23 @@ class InvenioRecordsLOM:
             pids_service=PIDsService(record_service_config, PIDManager),
         )
 
+        # pylint: disable-next=attribute-defined-outside-init
+        self.iiif_service = IIIFService(
+            records_service=self.records_service, config=None
+        )
+
     def init_resources(self, app):  # pylint: disable=unused-argument
         """Initialize resouces."""
         # pylint: disable-next=attribute-defined-outside-init
         self.draft_files_resource = FileResource(
             config=LOMDraftFilesResourceConfig,
             service=self.records_service.draft_files,
+        )
+
+        # pylint: disable-next=attribute-defined-outside-init
+        self.iiif_resource = IIIFResource(
+            config=LOMIIIFResourceConfig,
+            service=self.iiif_service,
         )
 
         # pylint: disable-next=attribute-defined-outside-init

--- a/invenio_records_lom/resources/__init__.py
+++ b/invenio_records_lom/resources/__init__.py
@@ -9,6 +9,7 @@
 
 from .config import (
     LOMDraftFilesResourceConfig,
+    LOMIIIFResourceConfig,
     LOMRecordFilesResourceConfig,
     LOMRecordResourceConfig,
 )
@@ -16,6 +17,7 @@ from .resources import LOMRecordResource
 
 __all__ = (
     "LOMDraftFilesResourceConfig",
+    "LOMIIIFResourceConfig",
     "LOMRecordFilesResourceConfig",
     "LOMRecordResource",
     "LOMRecordResourceConfig",

--- a/invenio_records_lom/resources/config.py
+++ b/invenio_records_lom/resources/config.py
@@ -9,6 +9,7 @@
 
 import marshmallow
 from flask_resources import JSONSerializer, ResponseHandler
+from invenio_rdm_records.resources import IIIFResourceConfig
 from invenio_records_resources.resources import RecordResourceConfig
 from invenio_records_resources.resources.files import FileResourceConfig
 
@@ -57,3 +58,10 @@ class LOMRecordResourceConfig(RecordResourceConfig):
     }
 
     response_handlers = record_serializer
+
+
+class LOMIIIFResourceConfig(IIIFResourceConfig):
+    """LOM IIIF Resource Config."""
+
+    blueprint_name = "lom_iiif"
+    url_prefix = "/lom/iiif"

--- a/invenio_records_lom/services/config.py
+++ b/invenio_records_lom/services/config.py
@@ -18,7 +18,11 @@ from invenio_drafts_resources.services.records.config import (
     is_record,
 )
 from invenio_rdm_records.services.components import AccessComponent, MetadataComponent
-from invenio_rdm_records.services.config import has_doi, is_record_and_has_doi
+from invenio_rdm_records.services.config import (
+    has_doi,
+    is_iiif_compatible,
+    is_record_and_has_doi,
+)
 from invenio_records_resources.services import (
     ConditionalLink,
     FileLink,
@@ -166,6 +170,9 @@ class LOMDraftFilesServiceConfig(FileServiceConfig, ConfiguratorMixin):
     file_links_item = {
         "commit": FileLink("{+api}/lom/{id}/draft/files/{key}/commit"),
         "content": FileLink("{+api}/lom/{id}/draft/files/{key}/content"),
+        "iiif_base": FileLink(
+            "{+api}/lom/iiif/draft:{id}:{key}", when=is_iiif_compatible
+        ),
         "self": FileLink("{+api}/lom/{id}/draft/files/{key}"),
     }
 
@@ -177,4 +184,8 @@ class LOMRecordFilesServiceConfig(FileServiceConfig, ConfiguratorMixin):
     permission_policy_cls = LOMRecordPermissionPolicy
 
     file_links_list = {}
-    file_links_item = {}
+    file_links_item = {
+        "iiif_base": FileLink(
+            "{+api}/lom/iiif/record:{id}:{key}", when=is_iiif_compatible
+        ),
+    }

--- a/invenio_records_lom/views.py
+++ b/invenio_records_lom/views.py
@@ -25,6 +25,7 @@ def init(state: BlueprintSetupState):
     registry.register(ext.records_service, service_id="lom-records")
     registry.register(ext.records_service.files, service_id="lom-files")
     registry.register(ext.records_service.draft_files, service_id="lom-draft-files")
+    registry.register(ext.iiif_service, service_id="lom-iiif")
 
 
 def create_records_bp(app: Flask):
@@ -43,3 +44,9 @@ def create_record_files_bp(app: Flask):
     """Create record files bluprint."""
     ext = app.extensions["invenio-records-lom"]
     return ext.record_files_resource.as_blueprint()
+
+
+def create_iiif_bp(app: Flask):
+    """Create IIIF blueprint."""
+    ext = app.extensions["invenio-records-lom"]
+    return ext.iiif_resource.as_blueprint()

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,7 @@ invenio_base.api_apps =
     invenio_records_lom = invenio_records_lom:InvenioRecordsLOM
 invenio_base.api_blueprints =
     invenio_records_lom_draft_files = invenio_records_lom.views:create_draft_files_bp
+    invenio_records_lom_iiif = invenio_records_lom.views:create_iiif_bp
     invenio_records_lom_record_files = invenio_records_lom.views:create_record_files_bp
     invenio_records_lom_records = invenio_records_lom.views:create_records_bp
     invenio_records_lom_resource_registerer = invenio_records_lom.views:blueprint


### PR DESCRIPTION
different file extensions call different previewers
image-preview requires:
  -  images to have associated preview-hyperlinks
  - an IIIF-resource configured to link those hyperlinks to a service
  - a service configured to look up files in lom-SQL-tables (instead of rdm-SQL-tables)