### PR TITLE
add "$schema"-key to jsons in database

### DIFF
--- a/invenio_records_lom/jsonschemas/lomrecords/lom-v1.0.0.json
+++ b/invenio_records_lom/jsonschemas/lomrecords/lom-v1.0.0.json
@@ -7,21 +7,9 @@
 
   "properties": {
     "$schema": {
-      "description": "This record's jsonschema.",
-      "type": "string"
-    },
-    "id": {
-      "description": "Invenio record identifier (integer).",
-      "type": "string"
-    },
-    "name": {
-      "description": "Author name.",
-      "type": "string"
-    },
-    "organization": {
-      "description": "Organization the author belongs to.",
+      "description": "Path to both, this record's jsonschema and this record's opensearch-mapping.",
       "type": "string"
     }
   },
-  "required": ["id", "name", "$schema"]
+  "required": ["$schema"]
 }

--- a/invenio_records_lom/jsonschemas/lomrecords/records/record-v1.0.0.json
+++ b/invenio_records_lom/jsonschemas/lomrecords/records/record-v1.0.0.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "local://lomrecords/records/record-v1.0.0.json",
+  "$comment": "Actual validation is done via `marshmallow`.",
+
+  "additionalProperties": false,
+  "title": "invenio-records-lom v1.0.0",
+  "type": "object",
+
+  "properties": {
+    "$schema": {
+      "description": "Relative path to both, this record's jsonschema and this record's opensearch-mapping.",
+      "type": "string"
+    },
+    "access": {},
+    "custom_fields": {},
+    "files": {},
+    "id": {},
+    "metadata": {},
+    "notes": {},
+    "pid": {},
+    "pids": {},
+    "provenance": {},
+    "resource_type": {},
+    "tombstone": {}
+  }
+}

--- a/invenio_records_lom/records/api.py
+++ b/invenio_records_lom/records/api.py
@@ -28,7 +28,12 @@ from invenio_drafts_resources.records import Draft, Record
 from invenio_drafts_resources.records.api import ParentRecord
 from invenio_pidstore.models import PIDStatus
 from invenio_rdm_records.records.systemfields import DraftStatus
-from invenio_records.systemfields import DictField, ModelField, RelationsField
+from invenio_records.systemfields import (
+    ConstantField,
+    DictField,
+    ModelField,
+    RelationsField,
+)
 from invenio_records_resources.records.api import FileRecord
 from invenio_records_resources.records.systemfields import (
     FilesField,
@@ -137,6 +142,7 @@ class LOMDraft(Draft, metaclass=LOMRecordMeta):
     is_published = PIDStatusCheckField(status=PIDStatus.REGISTERED, dump=True)
     pids = DictField()
     resource_type = DictField()
+    schema = ConstantField("$schema", "local://lomrecords/records/record-v1.0.0.json")
     status = DraftStatus()
 
 
@@ -182,6 +188,7 @@ class LOMRecord(Record, metaclass=LOMRecordMeta):
     is_published = PIDStatusCheckField(status=PIDStatus.REGISTERED, dump=True)
     pids = DictField()
     resource_type = DictField()
+    schema = ConstantField("$schema", "local://lomrecords/records/record-v1.0.0.json")
     status = DraftStatus()
 
 

--- a/invenio_records_lom/upgrade_scripts/__init__.py
+++ b/invenio_records_lom/upgrade_scripts/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023 Graz University of Technology.
+#
+# invenio-records-lom is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Migration scripts for `invenio-records-lom`."""

--- a/invenio_records_lom/upgrade_scripts/migrate_0_8_to_0_9.py
+++ b/invenio_records_lom/upgrade_scripts/migrate_0_8_to_0_9.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023 Graz University of Technology.
+#
+# invenio-records-lom is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Record migration script from invenio-records-lom 0.8 to 0.9.
+
+To upgrade call the whole file from within app-context.
+(e.g. via `pipenv run invenio shell /path/to/invenio_records_lom/upgrade_scripts/migrate_0_8_to_0_9.py`)
+(e.g. via `pipenv run invenio shell $(find $(pipenv --venv)/lib/*/site-packages/invenio_records_lom -name migrate_0_8_to_0_9.py))`)
+"""
+
+from copy import deepcopy
+
+import click
+from invenio_db import db
+
+from invenio_records_lom.records.models import LOMDraftMetadata, LOMRecordMetadata
+
+
+def execute_upgrade():
+    """Execute upgrade from `invenio-records-lom` `v0.8` to `v0.9`."""
+    click.secho('LOM upgrade: adding "$schema"-key to drafts and records', fg="green")
+
+    # upgrade JSONs in database; namely insert "$schema"-key
+    schema_key = "$schema"
+    schema_str = "local://lomrecords/records/record-v1.0.0.json"
+
+    # update drafts
+    for draft in LOMDraftMetadata.query.all():
+        old_json = draft.json
+        if not old_json:
+            continue  # for published/deleted drafts, json is None/empy
+        if old_json.get(schema_key):
+            continue  # don't update if already has "$schema"-key
+
+        # help SQLAlchemy in noticing a change by creating a new object
+        new_json = deepcopy(old_json)
+
+        new_json[schema_key] = schema_str
+        draft.json = new_json
+        db.session.add(draft)
+
+    # update records
+    for record in LOMRecordMetadata.query.all():
+        old_json = record.json
+        if not old_json:
+            continue  # for records with new-version/embargo, json is None/empty
+        if old_json.get(schema_key):
+            continue  # don't update if already has "$schema"-key
+
+        # help SQLAlchemy in noticing a change by creating a new object
+        new_json = deepcopy(old_json)
+
+        new_json[schema_key] = schema_str
+        record.json = new_json
+        db.session.add(record)
+
+    db.session.commit()
+    click.secho('Successfully added "$schema"-key to drafts and records!', fg="green")
+    click.secho(
+        "NOTE: this only updated the SQL-database, call `invenio lom reindex` to update opensearch-indices",
+        fg="red",
+    )
+
+
+if __name__ == "__main__":
+    # gets executed when file is called directly, but not when imported
+    execute_upgrade()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,14 @@ from invenio_records_lom.fixtures import create_fake_data
 @pytest.fixture(scope="module")
 def app_config(app_config):  # pylint: disable=redefined-outer-name
     """Override pytest-invenio app_config-fixture."""
+    # configuration for `jsonresolver`-package interoperability
+    app_config[
+        "RECORDS_REFRESOLVER_CLS"
+    ] = "invenio_records.resolver.InvenioRefResolver"
+    app_config[
+        "RECORDS_REFRESOLVER_STORE"
+    ] = "invenio_jsonschemas.proxies.current_refresolver_store"
+
     # Enable DOI minting...
     app_config["DATACITE_ENABLED"] = True
     app_config["DATACITE_USERNAME"] = "INVALID"


### PR DESCRIPTION
this key serves multiple purposes for the corresponding record:
- gives path to opensearch-mapping relative to its entrypoint
- gives path to jsonschema relative to its entrypoint
- allows to derive name of corresponding index

the last point is needed by OAI-PMH, but the others need be kept in line
verification of jsons is now done by marshmallow, hence the jsonschemas are just dummies

migration-scripts are located in `invenio_records_lom/upgrade_scripts`
to upgrade, run
  `$ pipenv run invenio shell /path/to/migrate_0_8_to_0_9.py`
  `$ invenio lom reindex`