### PR TITLE
add `format` and `resource-type` to upload-page

### DIFF
--- a/invenio_records_lom/resources/serializers/schemas/oai.py
+++ b/invenio_records_lom/resources/serializers/schemas/oai.py
@@ -190,7 +190,14 @@ class LocationSchema(ExcludeUnknownOrderedSchema):
 class TechnicalSchema(ExcludeUnknownOrderedSchema):
     """Schema for LOM-UIBK's `technical` category."""
 
-    format = fields.Str(required=True)  # e.g. video/mp4
+    format = fields.List(
+        fields.Str(
+            required=True,
+            validate=validate.Length(min=1, error="Format must not be empty."),
+        ),
+        required=True,
+        validate=validate.Length(min=1, max=1, error="Must have exactly one format."),
+    )  # e.g. ['video/mp4']
     # TODO: optional field: size
     location = fields.Nested(LocationSchema(), required=True)
     # TODO: optional field: thumbnail

--- a/invenio_records_lom/services/schemas/metadata.py
+++ b/invenio_records_lom/services/schemas/metadata.py
@@ -101,12 +101,57 @@ class ContributeSchema(Schema):
 
 
 class LifecycleSchema(Schema):
-    """Schema for Lom's `lifecycle category."""
+    """Schema for LOM's `lifecycle` category."""
 
     contribute = fields.List(
         fields.Nested(ContributeSchema()),
         validate=validate.Length(min=1, error="Enter at least one contribution."),
     )
+
+
+class LocationSchema(Schema):
+    """Schema for LOM's `technical.location`."""
+
+    text = fields.String(attribute="#text", data_key="#text")
+
+
+class TechnicalSchema(Schema):
+    """Schema for LOM's `technical` category."""
+
+    format = fields.List(
+        fields.String(
+            required=True,
+            validate=validate.Length(min=1, error="Missing data for required field."),
+        ),
+        validate=validate.Length(min=1, max=1, error="Must enter exactly one format."),
+    )
+    location = fields.Nested(LocationSchema)
+
+
+class LearningResourceTypeSchema(Schema):
+    """Scheam for LOM's `educational.learningresourcetype`."""
+
+    source = fields.Field(
+        required=True,
+        validate=validate.Equal(
+            {
+                "langstring": {
+                    "#text": "https://w3id.org/kim/hcrt/scheme",
+                    "lang": "x-none",
+                }
+            }
+        ),
+    )
+    id = fields.String(
+        required=True,
+        validate=validate.Length(min=1, error="Missing data for required field."),
+    )
+
+
+class EducationalSchema(Schema):
+    """Schema for LOM's `educational` category."""
+
+    learningresourcetype = fields.Nested(LearningResourceTypeSchema, required=True)
 
 
 class RightsSchema(Schema):
@@ -121,7 +166,7 @@ class RightsSchema(Schema):
 
 
 class TaxonSchema(Schema):
-    """Schema for Lom's `classification.taxonpath.taxon`-category."""
+    """Schema for LOM's `classification.taxonpath.taxon`-category."""
 
     id = fields.String(
         required=True,
@@ -190,6 +235,8 @@ class MetadataSchema(Schema):
 
     general = fields.Nested(GeneralSchema, required=True)
     lifecycle = fields.Nested(LifecycleSchema, required=True)
+    technical = fields.Nested(TechnicalSchema, rquired=True)
+    educational = fields.Nested(EducationalSchema, required=True)
     rights = fields.Nested(RightsSchema, required=True)
     classification = fields.Nested(
         ClassificationSchema,

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/LOMDepositForm.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/LOMDepositForm.js
@@ -85,6 +85,8 @@ export default class LOMDepositForm extends React.Component {
             // use longer paths once implemented in invenio...
             "metadata.general": i18next.t("Title"),
             "metadata.lifecycle": i18next.t("Contributors"),
+            "metadata.technical": i18next.t("Format"),
+            "metadata.educational": i18next.t("Resource Type"),
             "metadata.rights": i18next.t("License"),
             "metadata.classification": i18next.t("OEFOS"),
           }}

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/components.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/components.js
@@ -96,6 +96,22 @@ export function RequiredAccordion(props) {
         title={i18next.t("License")}
         vocabularyName="license"
       />
+      <DropdownField
+        fieldPath="metadata.form.format"
+        iconName="tag"
+        placeholder={i18next.t("Select Format")}
+        required
+        title={i18next.t("Format")}
+        vocabularyName="format"
+      />
+      <DropdownField
+        fieldPath="metadata.form.resourcetype"
+        iconName="tag"
+        placeholder={i18next.t("Select Resource Type")}
+        required
+        title={i18next.t("Resource Type")}
+        vocabularyName="resourcetype"
+      />
       <ArrayField
         addButtonLabel={i18next.t("Add Contributor")}
         defaultNewValue={{}}


### PR DESCRIPTION
also fills in publisher from config's `LOM_PUBLISHER` for new uploads

`metadata.technical.format` holds the MIME-type
for compatibility with older records,
- is of type `list[str]`
- but newly created records must have length of list ==1

`services/schemas/metadata.py` holds schemas that check record-data from incoming API-calls made by upload-page
errors thrown by these schemas are shown to the uploading user