### PR TITLE
clean up file headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (C) 2020 Graz University of Technology.
+Copyright (C) 2020-2023 Graz University of Technology.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/babel.ini
+++ b/babel.ini
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2021 Graz University of Technology.
+# Copyright (C) 2021, 2023 Graz University of Technology.
 #
-# Invenio-Records-Marc21 is free software; you can redistribute it and/or
-# modify it under the terms of the MIT License; see LICENSE file for more
-# details.
+# invenio-records-lom is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
 
 # Extraction from Python source files
 

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,3 +1,9 @@
+..
+    Copyright (C) 2020, 2023 Graz University of Technology.
+
+    invenio-records-lom is free software; you can redistribute it and/or modify it
+    under the terms of the MIT License; see LICENSE file for more details.
+
 License
 =======
 

--- a/invenio_records_lom/services/facets.py
+++ b/invenio_records_lom/services/facets.py
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2023 Graz University of Technology.
 #
-# Invenio is free software; you can redistribute it and/or modify it
+# invenio-records-lom is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """LOM facets (`facet` is opensearch-lingo for `search-query filter`)."""

--- a/invenio_records_lom/services/schemas/metadata.py
+++ b/invenio_records_lom/services/schemas/metadata.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 202 Graz University of Technology.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # invenio-records-lom is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_records_lom/templates/invenio_records_lom/base.html
+++ b/invenio_records_lom/templates/invenio_records_lom/base.html
@@ -1,14 +1,10 @@
 {# -*- coding: utf-8 -*-
 
-  This file is part of Invenio.
+  Copyright (C) 2022-2023 Graz University of Technology.
 
-  Copyright (C) 2022 Graz University of Technology.
-
-  invenio-records-lom is free software; you can redistribute it and/or
-  modify it under the terms of the MIT License; see LICENSE file for more
-  details.
+  invenio-records-lom is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
 #}
-
 
 {%- extends config.BASE_TEMPLATE %}
 

--- a/invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html
+++ b/invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html
@@ -1,9 +1,9 @@
 {# -*- coding: utf-8 -*-
 
-Copyright (C) 2023 Graz University of Technology.
+  Copyright (C) 2023 Graz University of Technology.
 
-invenio-records-lom is free software; you can redistribute it and/or modify it
-under the terms of the MIT License; see LICENSE file for more details.
+  invenio-records-lom is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
 #}
 
 {%- extends config.LOM_BASE_TEMPLATE %}

--- a/invenio_records_lom/templates/invenio_records_lom/records/macros/files.html
+++ b/invenio_records_lom/templates/invenio_records_lom/records/macros/files.html
@@ -2,10 +2,10 @@
 
   Copyright (C) 2020 CERN.
   Copyright (C) 2020 Northwestern University.
-  Copyright (C) 2021 Graz University of Technology.
+  Copyright (C) 2021, 2023 Graz University of Technology.
   Copyright (C) 2021 TU Wien.
 
-  Invenio-Records-LOM is free software; you can redistribute it and/or modify it
+  invenio-records-lom is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
 
   For the original code see the NOTE below.

--- a/invenio_records_lom/templates/invenio_records_lom/records/macros/tree.html
+++ b/invenio_records_lom/templates/invenio_records_lom/records/macros/tree.html
@@ -1,9 +1,11 @@
 {# -*- coding: utf-8 -*-
-  Copyright (C) 2022 Graz University of Technology.
 
-  Invenio-Records-LOM is free software; you can redistribute it and/or modify it
+  Copyright (C) 2022-2023 Graz University of Technology.
+
+  invenio-records-lom is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
 #}
+
 {%- macro make_dep_tree(relations, kind, rel_msg) -%}
 {% for relation in relations | selectattr("kind.value", "equalto", kind) -%}
 {% for identifier in relation.resource.identifier | selectattr("catalog", "equalto", "repo-pid") -%}

--- a/invenio_records_lom/templates/invenio_records_lom/search.html
+++ b/invenio_records_lom/templates/invenio_records_lom/search.html
@@ -1,8 +1,9 @@
-{#
+{# -*- coding: utf-8 -*-
+
   Copyright (C) 2022-2023 Graz University of Technology.
 
-  invenio-records-marc21 is free software; you can redistribute it and/or modify
-  it under the terms of the MIT License; see LICENSE file for more details.
+  invenio-records-lom is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
 #}
 
 {% set title = _("OER Search Results") %}

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/LOMDepositForm.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/LOMDepositForm.js
@@ -1,4 +1,3 @@
-// This file is part of invenio-records-lom
 // Copyright (C) 2022-2023 Graz University of Technology.
 //
 // invenio-records-lom is free software; you can redistribute it and/or modify it

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/components.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/components.js
@@ -1,4 +1,3 @@
-// This file is part of invenio-records-lom
 // Copyright (C) 2022-2023 Graz University of Technology.
 //
 // invenio-records-lom is free software; you can redistribute it and/or modify it

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/debug.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/debug.js
@@ -1,5 +1,4 @@
-// This file is part of invenio-records-lom
-// Copyright (C) 2022 Graz University of Technology.
+// Copyright (C) 2022-2023 Graz University of Technology.
 //
 // invenio-records-lom is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/fields.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/fields.js
@@ -1,7 +1,6 @@
-// This file is part of Invenio
 // Copyright (C) 2022-2023 Graz University of Technology.
 //
-// React-Invenio-Deposit is free software; you can redistribute it and/or modify it
+// invenio-records-lom is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
 import { getIn, useField, useFormikContext } from "formik";

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/index.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/index.js
@@ -1,7 +1,6 @@
-// This file is part of InvenioRDM
-// Copyright (C) 2022 Graz University of Technology.
+// Copyright (C) 2022-2023 Graz University of Technology.
 //
-// Invenio App RDM is free software; you can redistribute it and/or modify it
+// invenio-records-lom is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
 import React from "react"; // needs be in scope to use .jsx

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/serializers.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/serializers.js
@@ -1,4 +1,3 @@
-// This file is part of invenio-records-lom
 // Copyright (C) 2022-2023 Graz University of Technology.
 //
 // invenio-records-lom is free software; you can redistribute it and/or modify it

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/landing_page/LOMRecordManagement.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/landing_page/LOMRecordManagement.js
@@ -1,8 +1,8 @@
-// This file is part of invenio-records-lom
 // Copyright (C) 2023 Graz University of Technology.
 //
 // invenio-records-lom is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
+
 import React, { useState } from "react";
 import { http } from "react-invenio-forms";
 import { Button, Grid, Icon, Message } from "semantic-ui-react";

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/landing_page/index.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/landing_page/index.js
@@ -1,4 +1,3 @@
-// This file is part of invenio-records-lom
 // Copyright (C) 2023 Graz University of Technology.
 //
 // invenio-records-lom is free software; you can redistribute it and/or modify it

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/search/components.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/search/components.js
@@ -1,10 +1,7 @@
-// This file is part of Invenio.
+// Copyright (C) 2022-2023 Graz University of Technology.
 //
-// Copyright (C) 2022 Graz University of Technology.
-//
-// invenio-records-lom is free software; you can redistribute it and/or
-// modify it under the terms of the MIT License; see LICENSE file for more
-// details.
+// invenio-records-lom is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
 
 import React, { useState } from "react";
 import ReactDOM from "react-dom";

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/search/index.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/search/index.js
@@ -1,10 +1,7 @@
-// This file is part of Invenio.
+// Copyright (C) 2022-2023 Graz University of Technology.
 //
-// Copyright (C) 2022 Graz University of Technology.
-//
-// invenio-records-lom is free software; you can redistribute it and/or
-// modify it under the terms of the MIT License; see LICENSE file for more
-// details.
+// invenio-records-lom is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
 
 import { parametrize } from "react-overridable";
 import { createSearchAppInit } from "@js/invenio_search_ui";

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/less/invenio_records_lom/theme.less
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/less/invenio_records_lom/theme.less
@@ -1,9 +1,6 @@
-// This file is part of Invenio.
+// Copyright (C) 2022-2023 Graz University of Technology.
 //
-// Copyright (C) 2022 Graz University of Technology.
-//
-// invenio-records-lom is free software; you can redistribute it
-// and/or modify it under the terms of the MIT License; see LICENSE
-// file for more details.
+// invenio-records-lom is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
 
 /** LOM module page styles */

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/translations/invenio_records_lom/i18next-scanner.config.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/translations/invenio_records_lom/i18next-scanner.config.js
@@ -1,7 +1,6 @@
-// This file is part of React-Invenio-Deposit
-// Copyright (C) 2021 Graz University of Technology.
+// Copyright (C) 2023 Graz University of Technology.
 //
-// Invenio-app-rdm is free software; you can redistribute it and/or modify it
+// invenio-records-lom is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
 // list of func used to

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/translations/invenio_records_lom/i18next.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/translations/invenio_records_lom/i18next.js
@@ -1,7 +1,6 @@
-// This file is part of React-Invenio-Deposit
-// Copyright (C) 2021 Graz University of Technology.
+// Copyright (C) 2023 Graz University of Technology.
 //
-// Invenio-app-rdm is free software; you can redistribute it and/or modify it
+// invenio-records-lom is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
 import i18n from "i18next";

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/translations/invenio_records_lom/messages/index.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/translations/invenio_records_lom/messages/index.js
@@ -1,3 +1,8 @@
+// Copyright (C) 2023 Graz University of Technology.
+//
+// invenio-records-lom is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
 import TRANSLATE_DE from "./de/translations.json";
 import TRANSLATE_EN from "./en/translations.json";
 

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/translations/invenio_records_lom/scripts/compileCatalog.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/translations/invenio_records_lom/scripts/compileCatalog.js
@@ -1,7 +1,6 @@
-// This file is part of React-Invenio-Deposit
-// Copyright (C) 2021 Graz University of Technology.
+// Copyright (C) 2023 Graz University of Technology.
 //
-// Invenio-app-rdm is free software; you can redistribute it and/or modify it
+// invenio-records-lom is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
 const { readFileSync, writeFileSync } = require("fs");
@@ -13,7 +12,7 @@ const { languages } = require(`../package`).config;
 // it accepts the same options as the cli.
 // https://github.com/i18next/i18next-gettext-converter#options
 const options = {
-  /* you options here */
+  /* your options here */
 };
 
 function save(target) {

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/translations/invenio_records_lom/scripts/initCatalog.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/translations/invenio_records_lom/scripts/initCatalog.js
@@ -1,7 +1,6 @@
-// This file is part of React-Invenio-Deposit
-// Copyright (C) 2021 Graz University of Technology.
+// Copyright (C) 2023 Graz University of Technology.
 //
-// Invenio-app-rdm is free software; you can redistribute it and/or modify it
+// invenio-records-lom is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
 const { writeFileSync } = require("fs");

--- a/invenio_records_lom/ui/theme/webpack.py
+++ b/invenio_records_lom/ui/theme/webpack.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of Invenio.
-#
 # Copyright (C) 2021-2023 Graz University of Technology.
 #
-# invenio-records-lom is free software; you can redistribute it and/or
-# modify it under the terms of the MIT License; see LICENSE file for
-# more details.
+# invenio-records-lom is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
 
 """JS/CSS Webpack bundles for theme."""
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -3,11 +3,10 @@
 #
 # Copyright (C) 2019-2020 CERN.
 # Copyright (C) 2019-2020 Northwestern University.
-# Copyright (C) 2020-2022 Graz University of Technology.
+# Copyright (C) 2020-2023 Graz University of Technology.
 #
-# invenio-theme-tugraz is free software; you can redistribute it and/or
-# modify it under the terms of the MIT License; see LICENSE file for more
-# details.
+# invenio-records-lom is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
 
 
 # Quit on errors


### PR DESCRIPTION
some file-headers erroneously claimed the file to be part of a package other than `invenio-records-lom`
- fix that
- normalize file headers as to make them look the same
- fix some other issues with file headers