### PR TITLE
standardize rights-URLs passed to `LOMMetadata`

### DIFF
--- a/invenio_records_lom/utils/metadata.py
+++ b/invenio_records_lom/utils/metadata.py
@@ -15,6 +15,7 @@ from .util import (
     get_learningresourcetypedict,
     get_oefosdict,
     langstringify,
+    standardize_url,
     vocabularify,
 )
 
@@ -397,6 +398,7 @@ class LOMMetadata(BaseLOMMetadata):  # pylint: disable=too-many-public-methods
         :param str url: The url of the copyright license
                         (e.g. "https://creativecommons.org/licenses/by/4.0/")
         """
+        url = standardize_url(url)
         self.record["metadata.rights"] = {
             "copyrightandotherrestrictions": vocabularify("yes"),
             "url": url,

--- a/invenio_records_lom/utils/util.py
+++ b/invenio_records_lom/utils/util.py
@@ -8,6 +8,7 @@
 """Utilities for creation of LOM-compliant metadata."""
 
 
+import re
 from collections.abc import MutableMapping
 from csv import reader
 from importlib import resources
@@ -209,3 +210,16 @@ def durationify(datetime: str, description: str):
         inner["decription"] = description
 
     return {"duration": inner}
+
+
+def standardize_url(url: str) -> str:
+    """Return standardized version of `url`.
+
+    If `url`'s scheme is "http" or "https", make it "https".
+    Also ensure existence of a trailing "/".
+    """
+    pattern = re.compile("^https?://(.*?)/?$")
+    if m := pattern.match(url):
+        middle = m.group(1)  # excludes initial "https://", excludes trailing "/"
+        return f"https://{middle}/"
+    return url


### PR DESCRIPTION
facets consider http-URLs different from https-URLs
this standardizes rights-urls when `LOMMetadata` is used to build data