### PR TITLE
mark user-visible errors for translation

### DIFF
--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/serializers.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/serializers.js
@@ -299,7 +299,7 @@ export class LOMDepositRecordSerializer extends DepositRecordSerializer {
     );
 
     // serialize resource-type
-    const resourcetypeUrl = _get(metadata, "form.resourcetype.value");
+    const resourcetypeUrl = _get(metadata, "form.resourcetype.value", "");
     _set(metadata, "educational.learningresourcetype", {
       source: {
         langstring: {

--- a/invenio_records_lom/utils/util.py
+++ b/invenio_records_lom/utils/util.py
@@ -139,7 +139,8 @@ def get_learningresourcetypedict() -> dict[str, dict[str, str]]:
     Maps ((url-ending for "https://w3id.org/kim/hcrt/scheme/") -> labels_by_language),
     where labels_by_language maps (language_code -> label).
     """
-    with resources.open_text(__package__, "learning_resource_types.json") as file_like:
+    traversable = resources.files(__package__).joinpath("learning_resource_types.json")
+    with traversable.open("r", encoding="utf-8") as file_like:
         return load(file_like)
 
 
@@ -155,7 +156,8 @@ def get_oefosdict(language_code: str = "de") -> dict[str, str]:
         raise ValueError(f"OEFOS aren't available for language_code {language_code!r}.")
     filename = filenames_by_language[language_code.lower()]
 
-    with resources.open_text(__package__, filename) as file_pointer:
+    traversable = resources.files(__package__).joinpath(filename)
+    with traversable.open("r", encoding="utf-8") as file_pointer:
         file_reader = reader(file_pointer, delimiter=";")
 
         # discard header


### PR DESCRIPTION
When uploading via upload-page, the entered data will be validated by the backend.
If there are any `ValidationError`s, the corresponding error-message(s) will be shown to users of the upload-page.
These error-messages are not (yet) translated.

This PR marks those error-messages for translation.

Other error-messages shouldn't be visible to users.
Those haven't been marked for translation, but have been reworded.

Includes a commit to replace the deprecated function `importlib.resources.open_text`.
See [here](https://docs.python.org/3/library/importlib.resources.html#importlib.resources.open_text) for official documentation on what to replace it with.