### PR TITLE
deps: add missing dependency

### DIFF
--- a/invenio_records_lom/ui/theme/webpack.py
+++ b/invenio_records_lom/ui/theme/webpack.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2021-2023 Graz University of Technology.
+# Copyright (C) 2021-2024 Graz University of Technology.
 #
 # invenio-records-lom is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -30,6 +30,7 @@ theme = WebpackThemeBundle(
                 "@babel/runtime": "^7.9.0",
                 "react": "^16.13.0",
                 "react-dom": "^16.13.0",
+                "react-invenio-deposit": "^2.6.1",
             },
         },
     },


### PR DESCRIPTION
* the dependency was missing, because it was added previously by other
  packages, but it has been removed from there so it has to be added
  here now.
