### PR TITLE
Add statistical analytics to the records module

### DIFF
--- a/invenio_records_lom/config.py
+++ b/invenio_records_lom/config.py
@@ -8,13 +8,19 @@
 """Default configuration."""
 
 import idutils
+from celery.schedules import crontab
 from invenio_i18n import gettext as _
 from invenio_rdm_records.services.pids import providers
+from invenio_stats.aggregations import StatAggregator
+from invenio_stats.contrib.event_builders import build_file_unique_id
+from invenio_stats.processors import EventsIndexer, anonymize_user, flag_robots
+from invenio_stats.queries import TermsQuery
 
 from .resources.serializers import LOMToDataCite44Serializer
 from .services import facets
 from .services.permissions import LOMRecordPermissionPolicy
 from .services.pids import LOMDataCitePIDProvider
+from .utils import build_record_unique_id
 
 LOM_BASE_TEMPLATE = "invenio_records_lom/base.html"
 
@@ -46,10 +52,23 @@ LOM_SORT_OPTIONS = {
         "title": _("Newest"),
         "fields": ["-created"],
     },
+    "mostviewed": {
+        "title": _("Most viewed"),
+        "fields": ["-stats.all_versions.unique_views"],
+    },
+    "mostdownloaded": {
+        "title": _("Most downloaded"),
+        "fields": ["-stats.all_versions.unique_downloads"],
+    },
 }
 
 LOM_SEARCH = {
-    "sort": ["bestmatch", "newest"],
+    "sort": [
+        "bestmatch",
+        "newest",
+        "mostviewed",
+        "mostdownloaded",
+    ],
     "facets": [  # which facets to activate, see `LOM_FACETS` for facet-configuration
         "rights_license"
     ],
@@ -164,3 +183,201 @@ LOM_PERSISTENT_IDENTIFIERS = {
         "required": True/False,
     }
 """
+
+
+# Statistics configuration
+
+LOM_STATS_CELERY_TASKS = {
+    # indexing of statistics events & aggregations
+    "lom-stats-process-events": {
+        "task": "invenio_stats.tasks.process_events",
+        "args": [("lom-record-view", "lom-file-download")],
+        "schedule": crontab(
+            minute="15,45",
+        ),  # Every hour at minute 15 and 45
+    },
+    "lom-stats-aggregate-events": {
+        "task": "invenio_stats.tasks.aggregate_events",
+        "args": [
+            (
+                "lom-record-view-agg",
+                "lom-file-download-agg",
+            )
+        ],
+        "schedule": crontab(minute=7),  # Every hour at minute 7
+    },
+    "lom-reindex-stats": {
+        "task": "invenio_records_lom.services.tasks.lom_reindex_stats",
+        "args": [
+            (
+                "stats-lom-record-view",
+                "stats-lom-file-download",
+            )
+        ],
+        "schedule": crontab(minute="20"),
+    },
+}
+
+# Invenio-Stats
+# =============
+# See https://invenio-stats.readthedocs.io/en/latest/configuration.html
+
+LOM_STATS_EVENTS = {
+    "lom-file-download": {
+        "templates": "invenio_records_lom.records.statistics.templates.events.lom_file_download",
+        "event_builders": [
+            "invenio_rdm_records.resources.stats.file_download_event_builder",
+            "invenio_rdm_records.resources.stats.check_if_via_api",
+        ],
+        "cls": EventsIndexer,
+        "params": {
+            "preprocessors": [flag_robots, anonymize_user, build_file_unique_id]
+        },
+    },
+    "lom-record-view": {
+        "templates": "invenio_records_lom.records.statistics.templates.events.lom_record_view",
+        "event_builders": [
+            "invenio_rdm_records.resources.stats.record_view_event_builder",
+            "invenio_rdm_records.resources.stats.check_if_via_api",
+            "invenio_rdm_records.resources.stats.drop_if_via_api",
+        ],
+        "cls": EventsIndexer,
+        "params": {
+            "preprocessors": [flag_robots, anonymize_user, build_record_unique_id],
+        },
+    },
+}
+
+LOM_STATS_AGGREGATIONS = {
+    "lom-file-download-agg": {
+        "templates": "invenio_records_lom.records.statistics.templates.aggregations.aggr_lom_file_download",
+        "cls": StatAggregator,
+        "params": {
+            "event": "lom-file-download",
+            "field": "unique_id",
+            "interval": "day",
+            "index_interval": "month",
+            "copy_fields": {
+                "file_id": "file_id",
+                "file_key": "file_key",
+                "bucket_id": "bucket_id",
+                "recid": "recid",
+                "parent_recid": "parent_recid",
+            },
+            "metric_fields": {
+                "unique_count": (
+                    "cardinality",
+                    "unique_session_id",
+                    {"precision_threshold": 1000},
+                ),
+                "volume": ("sum", "size", {}),
+            },
+        },
+    },
+    "lom-record-view-agg": {
+        "templates": "invenio_records_lom.records.statistics.templates.aggregations.aggr_lom_record_view",
+        "cls": StatAggregator,
+        "params": {
+            "event": "lom-record-view",
+            "field": "unique_id",
+            "interval": "day",
+            "index_interval": "month",
+            "copy_fields": {
+                "recid": "recid",
+                "parent_recid": "parent_recid",
+                "via_api": "via_api",
+            },
+            "metric_fields": {
+                "unique_count": (
+                    "cardinality",
+                    "unique_session_id",
+                    {"precision_threshold": 1000},
+                ),
+            },
+            "query_modifiers": [lambda query, **_: query.filter("term", via_api=False)],
+        },
+    },
+}
+
+LOM_STATS_QUERIES = {
+    "lom-record-view": {
+        "cls": TermsQuery,
+        "permission_factory": None,
+        "params": {
+            "index": "stats-lom-record-view",
+            "doc_type": "lom-record-view-day-aggregation",
+            "copy_fields": {
+                "recid": "recid",
+                "parent_recid": "parent_recid",
+            },
+            "query_modifiers": [],
+            "required_filters": {
+                "recid": "recid",
+            },
+            "metric_fields": {
+                "views": ("sum", "count", {}),
+                "unique_views": ("sum", "unique_count", {}),
+            },
+        },
+    },
+    "lom-record-view-all-versions": {
+        "cls": TermsQuery,
+        "permission_factory": None,
+        "params": {
+            "index": "stats-lom-record-view",
+            "doc_type": "lom-record-view-day-aggregation",
+            "copy_fields": {
+                "parent_recid": "parent_recid",
+            },
+            "query_modifiers": [],
+            "required_filters": {
+                "parent_recid": "parent_recid",
+            },
+            "metric_fields": {
+                "views": ("sum", "count", {}),
+                "unique_views": ("sum", "unique_count", {}),
+            },
+        },
+    },
+    "lom-record-download": {
+        "cls": TermsQuery,
+        "permission_factory": None,
+        "params": {
+            "index": "stats-lom-file-download",
+            "doc_type": "lom-file-download-day-aggregation",
+            "copy_fields": {
+                "recid": "recid",
+                "parent_recid": "parent_recid",
+            },
+            "query_modifiers": [],
+            "required_filters": {
+                "recid": "recid",
+            },
+            "metric_fields": {
+                "downloads": ("sum", "count", {}),
+                "unique_downloads": ("sum", "unique_count", {}),
+                "data_volume": ("sum", "volume", {}),
+            },
+        },
+    },
+    "lom-record-download-all-versions": {
+        "cls": TermsQuery,
+        "permission_factory": None,
+        "params": {
+            "index": "stats-lom-file-download",
+            "doc_type": "lom-file-download-day-aggregation",
+            "copy_fields": {
+                "parent_recid": "parent_recid",
+            },
+            "query_modifiers": [],
+            "required_filters": {
+                "parent_recid": "parent_recid",
+            },
+            "metric_fields": {
+                "downloads": ("sum", "count", {}),
+                "unique_downloads": ("sum", "unique_count", {}),
+                "data_volume": ("sum", "volume", {}),
+            },
+        },
+    },
+}

--- a/invenio_records_lom/records/api.py
+++ b/invenio_records_lom/records/api.py
@@ -33,6 +33,7 @@ from invenio_rdm_records.records.systemfields import (
     HasDraftCheckField,
     RecordDeletionStatusField,
 )
+from invenio_records.dumpers import SearchDumper
 from invenio_records.systemfields import (
     ConstantField,
     DictField,
@@ -50,10 +51,12 @@ from invenio_requests.records.api import Request
 from invenio_requests.records.systemfields.relatedrecord import RelatedRecord
 
 from . import models
+from .dumpers import LomStatisticsDumperExt
 from .systemfields import (
     LOMDraftRecordIdProvider,
     LOMPIDFieldContext,
     LOMRecordIdProvider,
+    LomRecordStatisticsField,
     LOMResolver,
     ParentRecordAccessField,
     PIDLOMRelation,
@@ -127,6 +130,12 @@ class LOMDraft(Draft, metaclass=LOMRecordMeta):
     parent_record_cls = LOMParent
     versions_model_cls = models.LOMVersionsState
 
+    dumper = SearchDumper(
+        extensions=[
+            LomStatisticsDumperExt("stats"),
+        ]
+    )
+
     pid = PIDField(
         key="id",
         provider=LOMDraftRecordIdProvider,
@@ -198,6 +207,7 @@ class LOMRecord(Record, metaclass=LOMRecordMeta):
     schema = ConstantField("$schema", "local://lomrecords/records/record-v1.0.0.json")
     has_draft = HasDraftCheckField(LOMDraft)
     status = DraftStatus()
+    stats = LomRecordStatisticsField()
     deletion_status = RecordDeletionStatusField()
 
 

--- a/invenio_records_lom/records/dumpers/__init__.py
+++ b/invenio_records_lom/records/dumpers/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2018 CERN.
+# Copyright (C) 2024 Graz University of Technology.
+#
+# invenio-records-lom is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Statistics integration for RDM records."""
+
+from .statistics import LomStatisticsDumperExt
+
+__all__ = ("LomStatisticsDumperExt",)

--- a/invenio_records_lom/records/dumpers/statistics.py
+++ b/invenio_records_lom/records/dumpers/statistics.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# # Copyright (C) 2024 Graz University of Technology.
+#
+# invenio-records-lom is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Search dumpers for access-control information."""
+
+from flask import current_app
+from invenio_rdm_records.records.dumpers import StatisticsDumperExt
+from invenio_records.dictutils import dict_lookup
+
+from ..statistics import LomStatistics
+
+
+class LomStatisticsDumperExt(StatisticsDumperExt):
+    """Search dumper extension for record statistics.
+
+    On dump, it fetches the record's download & view statistics via Invenio-Stats
+    queries and dumps them into a field so that they are indexed in the search engine.
+    On load, it keeps the dumped values in the data dictionary, in order to enable
+    the record schema to dump them if present.
+    """
+
+    def dump(self, record, data):
+        """Dump the download & view statistics to the data dictionary."""
+        if record.is_draft:
+            return
+
+        recid = record.pid.pid_value
+        parent_recid = record.parent.pid.pid_value
+
+        try:
+            parent_data = dict_lookup(data, self.keys, parent=True)
+            parent_data[self.key] = LomStatistics.get_record_stats(
+                recid=recid, parent_recid=parent_recid
+            )
+        except KeyError as e:
+            current_app.logger.warning(e)

--- a/invenio_records_lom/records/mappings/os-v2/lomrecords/records/record-v1.0.0.json
+++ b/invenio_records_lom/records/mappings/os-v2/lomrecords/records/record-v1.0.0.json
@@ -137,6 +137,48 @@
             "type": "keyword"
           }
         }
+      },
+      "stats": {
+        "properties": {
+          "this_version": {
+            "properties": {
+              "views": {
+                "type": "integer"
+              },
+              "unique_views": {
+                "type": "integer"
+              },
+              "downloads": {
+                "type": "integer"
+              },
+              "unique_downloads": {
+                "type": "integer"
+              },
+              "data_volume": {
+                "type": "double"
+              }
+            }
+          },
+          "all_versions": {
+            "properties": {
+              "views": {
+                "type": "integer"
+              },
+              "unique_views": {
+                "type": "integer"
+              },
+              "downloads": {
+                "type": "integer"
+              },
+              "unique_downloads": {
+                "type": "integer"
+              },
+              "data_volume": {
+                "type": "double"
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/invenio_records_lom/records/statistics/__init__.py
+++ b/invenio_records_lom/records/statistics/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2018 CERN.
+# Copyright (C) 2024 Graz University of Technology.
+#
+# invenio-records-lom is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Statistics integration for lom records."""
+
+from .api import LomStatistics
+
+__all__ = ("LomStatistics",)

--- a/invenio_records_lom/records/statistics/api.py
+++ b/invenio_records_lom/records/statistics/api.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+#
+# Copyright (C) 2019 CERN.
+# Copyright (C) 2022 TU Wien.
+# Copyright (C) 2024 Graz University of Technology.
+#
+# invenio-records-lom is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Permission factories for invenio-records-lom.
+
+In contrast to the very liberal defaults provided by invenio-records-lom, these permission
+factories deny access unless otherwise specified.
+"""
+
+from flask import current_app
+from invenio_rdm_records.records.stats import Statistics
+
+
+class LomStatistics(Statistics):
+    """Lom statistics API class."""
+
+    prefix = "lom-record"
+
+    @classmethod
+    def get_record_stats(cls, recid, parent_recid):
+        """Fetch the statistics for the given record."""
+        try:
+            views = cls._get_query(f"{cls.prefix}-view").run(recid=recid)
+            views_all = cls._get_query(f"{cls.prefix}-view-all-versions").run(
+                parent_recid=parent_recid
+            )
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            # e.g. opensearchpy.exceptions.NotFoundError
+            # when the aggregation search index hasn't been created yet
+            current_app.logger.warning(e)
+
+            fallback_result = {
+                "views": 0,
+                "unique_views": 0,
+            }
+            views = views_all = downloads = downloads_all = fallback_result
+
+        try:
+            downloads = cls._get_query(f"{cls.prefix}-download").run(recid=recid)
+            downloads_all = cls._get_query(f"{cls.prefix}-download-all-versions").run(
+                parent_recid=parent_recid
+            )
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            # same as above, but for failure in the download statistics
+            # because they are a separate index that can fail independently
+            current_app.logger.warning(e)
+
+            fallback_result = {
+                "downloads": 0,
+                "unique_downloads": 0,
+                "data_volume": 0,
+            }
+            downloads = downloads_all = fallback_result
+
+        stats = {
+            "this_version": {
+                "views": views["views"],
+                "unique_views": views["unique_views"],
+                "downloads": downloads["downloads"],
+                "unique_downloads": downloads["unique_downloads"],
+                "data_volume": downloads["data_volume"],
+            },
+            "all_versions": {
+                "views": views_all["views"],
+                "unique_views": views_all["unique_views"],
+                "downloads": downloads_all["downloads"],
+                "unique_downloads": downloads_all["unique_downloads"],
+                "data_volume": downloads_all["data_volume"],
+            },
+        }
+
+        return stats

--- a/invenio_records_lom/records/statistics/templates/__init__.py
+++ b/invenio_records_lom/records/statistics/templates/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2018 CERN.
+# Copyright (C) 2024 Graz University of Technology.
+#
+# invenio-records-lom is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Statistics search index templates."""

--- a/invenio_records_lom/records/statistics/templates/aggregations/__init__.py
+++ b/invenio_records_lom/records/statistics/templates/aggregations/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2018 CERN.
+# Copyright (C) 2023 TU Wien.
+# Copyright (C) 2024 Graz University of Technology.
+#
+# invenio-records-lom is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Aggregations search index templates."""

--- a/invenio_records_lom/records/statistics/templates/aggregations/aggr_lom_file_download/__init__.py
+++ b/invenio_records_lom/records/statistics/templates/aggregations/aggr_lom_file_download/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2018 CERN.
+# Copyright (C) 2023 TU Wien.
+# Copyright (C) 2024 Graz University of Technology.
+#
+# invenio-records-lom is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""File download aggregations search index templates."""

--- a/invenio_records_lom/records/statistics/templates/aggregations/aggr_lom_file_download/os-v2/__init__.py
+++ b/invenio_records_lom/records/statistics/templates/aggregations/aggr_lom_file_download/os-v2/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Graz University of Technology.
+#
+# invenio-records-lom is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+"""File download aggregations OpenSearch index templates."""

--- a/invenio_records_lom/records/statistics/templates/aggregations/aggr_lom_file_download/os-v2/aggr-lom-file-download-v1.0.0.json
+++ b/invenio_records_lom/records/statistics/templates/aggregations/aggr_lom_file_download/os-v2/aggr-lom-file-download-v1.0.0.json
@@ -1,0 +1,72 @@
+{
+  "index_patterns": ["__SEARCH_INDEX_PREFIX__stats-lom-file-download-*"],
+  "settings": {
+    "index": {
+      "refresh_interval": "5s"
+    }
+  },
+  "mappings": {
+    "dynamic_templates": [
+      {
+        "date_fields": {
+          "match_mapping_type": "date",
+          "mapping": {
+            "type": "date",
+            "format": "date_optional_time"
+          }
+        }
+      }
+    ],
+    "date_detection": false,
+    "dynamic": "strict",
+    "numeric_detection": false,
+    "properties": {
+      "timestamp": {
+        "type": "date",
+        "format": "date_optional_time"
+      },
+      "count": {
+        "type": "integer"
+      },
+      "unique_count": {
+        "type": "integer"
+      },
+      "file_id": {
+        "type": "keyword"
+      },
+      "file_key": {
+        "type": "keyword"
+      },
+      "bucket_id": {
+        "type": "keyword"
+      },
+      "volume": {
+        "type": "double"
+      },
+      "unique_id": {
+        "type": "keyword"
+      },
+      "record_id": {
+        "type": "keyword"
+      },
+      "recid": {
+        "type": "keyword"
+      },
+      "parent_id": {
+        "type": "keyword"
+      },
+      "parent_recid": {
+        "type": "keyword"
+      },
+      "via_api": {
+        "type": "boolean"
+      },
+      "updated_timestamp": {
+        "type": "date"
+      }
+    }
+  },
+  "aliases": {
+    "__SEARCH_INDEX_PREFIX__stats-lom-file-download": {}
+  }
+}

--- a/invenio_records_lom/records/statistics/templates/aggregations/aggr_lom_record_view/__init__.py
+++ b/invenio_records_lom/records/statistics/templates/aggregations/aggr_lom_record_view/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2018 CERN.
+# Copyright (C) 2023 TU Wien.
+# Copyright (C) 2024 Graz University of Technology.
+#
+# invenio-records-lom is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Record views aggregations search index templates."""

--- a/invenio_records_lom/records/statistics/templates/aggregations/aggr_lom_record_view/os-v2/__init__.py
+++ b/invenio_records_lom/records/statistics/templates/aggregations/aggr_lom_record_view/os-v2/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Graz University of Technology.
+#
+# invenio-records-lom is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+"""Record view aggregations OpenSearch index templates."""

--- a/invenio_records_lom/records/statistics/templates/aggregations/aggr_lom_record_view/os-v2/aggr-lom-record-view-v1.0.0.json
+++ b/invenio_records_lom/records/statistics/templates/aggregations/aggr_lom_record_view/os-v2/aggr-lom-record-view-v1.0.0.json
@@ -1,0 +1,49 @@
+{
+  "index_patterns": ["__SEARCH_INDEX_PREFIX__stats-lom-record-view-*"],
+  "settings": {
+    "index": {
+      "refresh_interval": "5s"
+    }
+  },
+  "mappings": {
+    "date_detection": false,
+    "dynamic": "strict",
+    "numeric_detection": false,
+    "properties": {
+      "timestamp": {
+        "type": "date",
+        "format": "date_optional_time"
+      },
+      "count": {
+        "type": "integer"
+      },
+      "unique_count": {
+        "type": "integer"
+      },
+      "record_id": {
+        "type": "keyword"
+      },
+      "recid": {
+        "type": "keyword"
+      },
+      "parent_id": {
+        "type": "keyword"
+      },
+      "parent_recid": {
+        "type": "keyword"
+      },
+      "unique_id": {
+        "type": "keyword"
+      },
+      "via_api": {
+        "type": "boolean"
+      },
+      "updated_timestamp": {
+        "type": "date"
+      }
+    }
+  },
+  "aliases": {
+    "__SEARCH_INDEX_PREFIX__stats-lom-record-view": {}
+  }
+}

--- a/invenio_records_lom/records/statistics/templates/events/__init__.py
+++ b/invenio_records_lom/records/statistics/templates/events/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2018 CERN.
+# Copyright (C) 2023 TU Wien.
+# Copyright (C) 2024 Graz University of Technology.
+#
+# invenio-records-lom is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Statistics events search index templates."""

--- a/invenio_records_lom/records/statistics/templates/events/lom_file_download/__init__.py
+++ b/invenio_records_lom/records/statistics/templates/events/lom_file_download/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Graz University of Technology.
+#
+# invenio-records-lom is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+"""File download event OpenSearch index templates."""

--- a/invenio_records_lom/records/statistics/templates/events/lom_file_download/os-v2/__init__.py
+++ b/invenio_records_lom/records/statistics/templates/events/lom_file_download/os-v2/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Graz University of Technology.
+#
+# invenio-records-lom is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+"""File download event OpenSearch index templates."""

--- a/invenio_records_lom/records/statistics/templates/events/lom_file_download/os-v2/lom-file-download-v1.0.0.json
+++ b/invenio_records_lom/records/statistics/templates/events/lom_file_download/os-v2/lom-file-download-v1.0.0.json
@@ -1,0 +1,96 @@
+{
+  "index_patterns": ["__SEARCH_INDEX_PREFIX__events-stats-lom-file-download-*"],
+  "settings": {
+    "index": {
+      "refresh_interval": "5s"
+    }
+  },
+  "mappings": {
+    "dynamic_templates": [
+      {
+        "date_fields": {
+          "match_mapping_type": "date",
+          "mapping": {
+            "type": "date",
+            "format": "strict_date_hour_minute_second"
+          }
+        }
+      }
+    ],
+    "date_detection": false,
+    "dynamic": "strict",
+    "numeric_detection": false,
+    "properties": {
+      "timestamp": {
+        "type": "date",
+        "format": "strict_date_hour_minute_second"
+      },
+      "bucket_id": {
+        "type": "keyword"
+      },
+      "file_id": {
+        "type": "keyword"
+      },
+      "file_key": {
+        "type": "keyword"
+      },
+      "unique_id": {
+        "type": "keyword"
+      },
+      "country": {
+        "type": "keyword"
+      },
+      "visitor_id": {
+        "type": "keyword"
+      },
+      "is_machine": {
+        "type": "boolean"
+      },
+      "is_robot": {
+        "type": "boolean"
+      },
+      "unique_session_id": {
+        "type": "keyword"
+      },
+      "size": {
+        "type": "double"
+      },
+      "referrer": {
+        "type": "keyword"
+      },
+      "ip_address": {
+        "type": "keyword"
+      },
+      "user_agent": {
+        "type": "keyword"
+      },
+      "user_id": {
+        "type": "keyword"
+      },
+      "session_id": {
+        "type": "keyword"
+      },
+      "record_id": {
+        "type": "keyword"
+      },
+      "recid": {
+        "type": "keyword"
+      },
+      "parent_id": {
+        "type": "keyword"
+      },
+      "parent_recid": {
+        "type": "keyword"
+      },
+      "via_api": {
+        "type": "boolean"
+      },
+      "updated_timestamp": {
+        "type": "date"
+      }
+    }
+  },
+  "aliases": {
+    "__SEARCH_INDEX_PREFIX__events-stats-lom-file-download": {}
+  }
+}

--- a/invenio_records_lom/records/statistics/templates/events/lom_record_view/__init__.py
+++ b/invenio_records_lom/records/statistics/templates/events/lom_record_view/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2018 CERN.
+# Copyright (C) 2023 TU Wien.
+# Copyright (C) 2024 Graz University of Technology.
+#
+# invenio-records-lom is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Record views search index templates."""

--- a/invenio_records_lom/records/statistics/templates/events/lom_record_view/os-v2/__init__.py
+++ b/invenio_records_lom/records/statistics/templates/events/lom_record_view/os-v2/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Graz University of Technology.
+#
+# invenio-records-lom is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+"""Record view event OpenSearch index templates."""

--- a/invenio_records_lom/records/statistics/templates/events/lom_record_view/os-v2/lom-record-view-v1.0.0.json
+++ b/invenio_records_lom/records/statistics/templates/events/lom_record_view/os-v2/lom-record-view-v1.0.0.json
@@ -1,0 +1,75 @@
+{
+  "index_patterns": [
+    "__SEARCH_INDEX_PREFIX__events-stats-lom-record-view-*"
+  ],
+  "settings": {
+    "index": {
+      "refresh_interval": "5s"
+    }
+  },
+  "mappings": {
+    "date_detection": false,
+    "dynamic": "strict",
+    "numeric_detection": false,
+    "properties": {
+      "timestamp": {
+        "type": "date",
+        "format": "strict_date_hour_minute_second"
+      },
+      "labels": {
+        "type": "keyword"
+      },
+      "country": {
+        "type": "keyword"
+      },
+      "visitor_id": {
+        "type": "keyword"
+      },
+      "is_robot": {
+        "type": "boolean"
+      },
+      "unique_id": {
+        "type": "keyword"
+      },
+      "unique_session_id": {
+        "type": "keyword"
+      },
+      "referrer": {
+        "type": "keyword"
+      },
+      "ip_address": {
+        "type": "keyword"
+      },
+      "user_agent": {
+        "type": "keyword"
+      },
+      "user_id": {
+        "type": "keyword"
+      },
+      "session_id": {
+        "type": "keyword"
+      },
+      "record_id": {
+        "type": "keyword"
+      },
+      "recid": {
+        "type": "keyword"
+      },
+      "parent_id": {
+        "type": "keyword"
+      },
+      "parent_recid": {
+        "type": "keyword"
+      },
+      "via_api": {
+        "type": "boolean"
+      },
+      "updated_timestamp": {
+        "type": "date"
+      }
+    }
+  },
+  "aliases": {
+    "__SEARCH_INDEX_PREFIX__events-stats-lom-record-view": {}
+  }
+}

--- a/invenio_records_lom/records/systemfields/__init__.py
+++ b/invenio_records_lom/records/systemfields/__init__.py
@@ -20,6 +20,7 @@ from .context import LOMPIDFieldContext
 from .providers import LOMDraftRecordIdProvider, LOMRecordIdProvider
 from .relations import PIDLOMRelation
 from .resolver import LOMResolver
+from .statistics import LomRecordStatisticsField
 
 __all__ = (
     "LOMDraftRecordIdProvider",
@@ -29,4 +30,5 @@ __all__ = (
     "ParentRecordAccessField",
     "PIDLOMRelation",
     "RecordAccessField",
+    "LomRecordStatisticsField",
 )

--- a/invenio_records_lom/records/systemfields/statistics.py
+++ b/invenio_records_lom/records/systemfields/statistics.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# # Copyright (C) 2024 Graz University of Technology.
+#
+# invenio-records-lom is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Cached transient field for record statistics."""
+
+from invenio_rdm_records.records.systemfields import RecordStatisticsField
+from invenio_search.proxies import current_search_client
+from invenio_search.utils import build_alias_name
+
+from ..statistics import LomStatistics
+
+
+class LomRecordStatisticsField(RecordStatisticsField):
+    """Field for lazy fetching and caching (but not storing) of tugraz record statistics."""
+
+    api = LomStatistics
+    """lom api """
+
+    def _get_record_stats(self, record):
+        """Get the record's statistics from either record or aggregation index."""
+        stats = None
+        recid, parent_recid = record["id"], record.parent["id"]
+
+        try:
+            # for more consistency between search results and each record's details,
+            # we try to get the statistics from the record's search index first
+            # note: this field is dumped into the record's data before indexing
+            #       by the search dumper extension "StatisticsDumperExt"
+            res = current_search_client.get(
+                # pylint: disable-next=protected-access
+                index=build_alias_name(record.index._name),
+                id=record.id,
+                params={"_source_includes": "stats"},
+            )
+            stats = res["_source"]["stats"]
+        except Exception:  # pylint: disable=broad-exception-caught
+            stats = None
+
+        # as a fallback, use the more up-to-date aggregations indices
+        return stats or self.api.get_record_stats(
+            recid=recid, parent_recid=parent_recid
+        )

--- a/invenio_records_lom/services/schemas/records.py
+++ b/invenio_records_lom/services/schemas/records.py
@@ -25,6 +25,7 @@ from werkzeug.local import LocalProxy
 
 from .fields import ControlledVocabularyField
 from .metadata import MetadataSchema
+from .statistics import LomStatisticSchema
 
 
 def validate_lom_scheme(scheme: str):
@@ -50,6 +51,8 @@ class LOMRecordSchema(RDMRecordSchema):
     resource_type = ControlledVocabularyField(
         vocabulary=LocalProxy(lambda: current_app.config["LOM_RESOURCE_TYPES"]),
     )
+
+    stats = NestedAttribute(LomStatisticSchema, dump_only=True)
 
     @pre_dump
     @pre_load

--- a/invenio_records_lom/services/schemas/statistics.py
+++ b/invenio_records_lom/services/schemas/statistics.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Graz University of Technology.
+#
+# invenio-records-lom is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Tugraz statistic record schemas."""
+
+
+from marshmallow import Schema, fields
+
+
+class PartialStatisticSchema(Schema):
+    """Schema for a part of the record statistics.
+
+    This fits both the statistics for "this version" as well as
+    "all versions", because they have the same shape.
+    """
+
+    views = fields.Int()
+    unique_views = fields.Int()
+    downloads = fields.Int()
+    unique_downloads = fields.Int()
+    data_volume = fields.Float()
+
+
+class LomStatisticSchema(Schema):
+    """Schema for the entire record statistics."""
+
+    this_version = fields.Nested(PartialStatisticSchema)
+    all_versions = fields.Nested(PartialStatisticSchema)

--- a/invenio_records_lom/services/tasks.py
+++ b/invenio_records_lom/services/tasks.py
@@ -7,8 +7,15 @@
 
 """Celery tasks for LOM module."""
 
+
+from datetime import datetime, timedelta
+
 from celery import shared_task
 from invenio_access.permissions import system_identity
+from invenio_search.engine import dsl
+from invenio_search.proxies import current_search_client
+from invenio_search.utils import prefix_index
+from invenio_stats.bookmark import BookmarkAPI
 
 from ..proxies import current_records_lom
 
@@ -21,3 +28,39 @@ def register_or_update_pid(recid: str, scheme: str):
         identity=system_identity,
         scheme=scheme,
     )
+
+
+@shared_task(ignore_result=True)
+def lom_reindex_stats(stats_indices):
+    """Reindex the documents where the stats have changed."""
+    bm = BookmarkAPI(current_search_client, "lom_stats_reindex", "day")
+    last_run = bm.get_bookmark()
+    if not last_run:
+        # If this is the first time that we run, let's do it for the documents of the last week
+        last_run = (datetime.utcnow() - timedelta(days=7)).isoformat()
+    reindex_start_time = datetime.utcnow().isoformat()
+    indices = ",".join(map(lambda x: prefix_index(x) + "*", stats_indices))
+
+    all_parents = set()
+    query = dsl.Search(
+        using=current_search_client,
+        index=indices,
+    ).filter({"range": {"updated_timestamp": {"gte": last_run}}})
+
+    for result in query.scan():
+        parent_id = result.parent_recid
+        all_parents.add(parent_id)
+
+    if all_parents:
+        all_parents_list = list(all_parents)
+        step = 10000
+        end = len(list(all_parents))
+        for i in range(0, end, step):
+            records_q = dsl.Q("terms", parent__id=all_parents_list[i : i + step])
+            current_records_lom.record_service.reindex(
+                params={"allversions": True},
+                identity=system_identity,
+                search_query=records_q,
+            )
+    bm.set_bookmark(reindex_start_time)
+    return f"{len(all_parents)} documents reindexed"

--- a/invenio_records_lom/templates/invenio_records_lom/record.html
+++ b/invenio_records_lom/templates/invenio_records_lom/record.html
@@ -150,6 +150,9 @@
     </div>
   </section>
   {% endif %}
+  {%  if record.stats %}
+    {% include "invenio_records_lom/records/helpers/statistics.html" %}
+  {% endif %}
   {% include "invenio_app_rdm/records/details/side_bar/licenses.html" %}
   {% if record.ui.location %}
     <section id="original-content" aria-label="" class="ui segment rdm-sidebar">

--- a/invenio_records_lom/templates/invenio_records_lom/records/helpers/statistics.html
+++ b/invenio_records_lom/templates/invenio_records_lom/records/helpers/statistics.html
@@ -1,0 +1,32 @@
+{# -*- coding: utf-8 -*-
+  Copyright (C) 2024 Graz University of Technology.
+
+  invenio-records-lom is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
+  <section id="record-statistics" class="ui segment rdm-sidebar">
+    <div class="ui tiny two statistics rel-mt-1">
+      {% set all_versions = record.stats.all_versions %} {% set this_version =
+      record.stats.this_version %}
+
+      <div class="ui statistic">
+        <div class="value">
+          {{ all_versions.unique_views|compact_number(max_value=1_000_000) }}
+        </div>
+        <div class="label">
+          <i aria-hidden="true" class="eye icon"></i>
+          {{ _("Views") }}
+        </div>
+      </div>
+
+      <div class="ui statistic">
+        <div class="value">
+          {{ all_versions.unique_downloads|compact_number(max_value=1_000_000) }}
+        </div>
+        <div class="label">
+          <i aria-hidden="true" class="download icon"></i>
+          {{ _("Downloads") }}
+        </div>
+      </div>
+    </div>
+  </section>

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/search/components.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/search/components.js
@@ -1,11 +1,12 @@
-// Copyright (C) 2022-2023 Graz University of Technology.
+// Copyright (C) 2022-2024 Graz University of Technology.
 //
 // invenio-records-lom is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
+import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { get, truncate } from "lodash";
-import { Card, Icon, Item, Label } from "semantic-ui-react";
+import { Card, Icon, Item, Label, Popup } from "semantic-ui-react";
 import { EditButton } from "@js/invenio_records_lom/components/EditButton";
 
 export const LOMBucketAggregationElement = ({ title, containerCmp }) => {
@@ -29,6 +30,48 @@ export const LOMBucketAggregationElement = ({ title, containerCmp }) => {
       </Card.Content>
     </Card>
   );
+};
+
+
+export const LomStats = ({ uniqueViews, uniqueDownloads }) => {
+  return (
+    <>
+      {uniqueViews != null && (
+        <Popup
+          size="tiny"
+          content={"Views"}
+          trigger={
+            <Label className="transparent">
+              <Icon name="eye" />
+              {uniqueViews}
+            </Label>
+          }
+        />
+      )}
+      {uniqueDownloads != null && (
+        <Popup
+          size="tiny"
+          content={"Downloads"}
+          trigger={
+            <Label className="transparent">
+              <Icon name="download" />
+              {uniqueDownloads}
+            </Label>
+          }
+        />
+      )}
+    </>
+  );
+};
+
+LomStats.propTypes = {
+  uniqueViews: PropTypes.number,
+  uniqueDownloads: PropTypes.number,
+};
+
+LomStats.defaultProps = {
+  uniqueViews: null,
+  uniqueDownloads: null,
 };
 
 export const LOMRecordResultsListItem = ({ result, index }) => {
@@ -63,6 +106,9 @@ export const LOMRecordResultsListItem = ({ result, index }) => {
   );
 
   const subjects = [];
+
+  const uniqueViews = get(result, "stats.all_versions.unique_views", 0);
+  const uniqueDownloads = get(result, "stats.all_versions.unique_downloads", 0);
 
   const viewLink = `/oer/${result.id}`;
 
@@ -107,9 +153,15 @@ export const LOMRecordResultsListItem = ({ result, index }) => {
             </Label>
           ))}
           {createdDate && (
-            <div>
+            <div className="flex justify-space-between align-items-end">
               <small>
                 Uploaded on <span>{createdDate}</span>
+              </small>
+              <small>
+                <LomStats
+                  uniqueViews={uniqueViews}
+                  uniqueDownloads={uniqueDownloads}
+                />
               </small>
             </div>
           )}

--- a/invenio_records_lom/utils/__init__.py
+++ b/invenio_records_lom/utils/__init__.py
@@ -8,6 +8,7 @@
 """Utilities for creation of LOM-compliant metadata."""
 
 from .metadata import LOMCourseMetadata, LOMMetadata
+from .statistics import build_record_unique_id
 from .util import DotAccessWrapper, get_learningresourcetypedict, get_oefosdict
 from .vcard import make_lom_vcard
 
@@ -18,4 +19,5 @@ __all__ = (
     "LOMMetadata",
     "LOMCourseMetadata",
     "make_lom_vcard",
+    "build_record_unique_id",
 )

--- a/invenio_records_lom/utils/statistics.py
+++ b/invenio_records_lom/utils/statistics.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Graz University of Technology.
+#
+# invenio-records-lom is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""statistic utils module."""
+
+
+def build_record_unique_id(doc):
+    """Build record unique identifier."""
+    doc["unique_id"] = f"{doc['recid']}_{doc['parent_recid']}"
+    return doc

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ zip_safe = False
 install_requires =
     invenio-previewer>=1.3.6
     invenio-rdm-records>=1.1.0
+    invenio-stats>=1.0.0
     SQLAlchemy-Continuum<1.4  # version 1.4 failed tests on 2023-07-13
 
 [options.extras_require]


### PR DESCRIPTION
This pull request introduces a statistical feature from `invenio-stats` for this data model. This includes the aggregation of events and display of `views` and `download`  for publication records. The implementation enhances the module by providing deeper insights into user interactions and system performance relating to specific records.

### Key Changes:
1. **Record Mapping Adjustments**:
   - Modified the record mapping to include statistic fields stored in the record.

2. **Statistics Template**:
   - Added a new Jinja2 template for statistical event visualizations. This template is designed to display aggregated data and is integrated within the existing module UI.

3. **Aggregation Functionality**:
   - Integrated ìnvenio-stats` backend functionality to query aggregated events data for a record.

5. **Enhanced Configuration Flexibility**:
   - Configuration blueprints can now be dynamically loaded, which permits instance-specific configurations without altering the core module code. 

### Testing:
Add to `invenio.cfg` following lines:

```python
from invenio_records_lom.config import LOM_STATS_CELERY_TASKS, LOM_STATS_EVENTS, LOM_STATS_AGGREGATIONS, LOM_STATS_QUERIES
from invenio_app_rdm.config import CELERY_BEAT_SCHEDULE, STATS_EVENTS, STATS_AGGREGATIONS, STATS_QUERIES

CELERY_BEAT_SCHEDULE.update(LOM_STATS_CELERY_TASKS)
STATS_EVENTS.update(LOM_STATS_EVENTS)
STATS_AGGREGATIONS.update(LOM_STATS_AGGREGATIONS)
STATS_QUERIES.update(LOM_STATS_QUERIES)
```