### PR TITLE
fix: use `dict` for `RequestParser` args

### DIFF
--- a/invenio_records_lom/resources/config.py
+++ b/invenio_records_lom/resources/config.py
@@ -59,12 +59,13 @@ class LOMRecordResourceConfig(RecordResourceConfig):
         },
     )
 
-    request_view_args = MappingProxyType(
-        {
-            "pid_value": fields.Str(),
-            "scheme": fields.Str(),
-        },
-    )
+    # `flask_resources.parser.RequestParser.__init__` requires
+    # `isinstance(request_view_args, dict)` to treat this correctly
+    # this still *should* probably be read-only, but that would require upstream-changes
+    request_view_args = {  # noqa: RUF012
+        "pid_value": fields.Str(),
+        "scheme": fields.Str(),
+    }
 
     response_handlers = record_serializer
 


### PR DESCRIPTION
`flask_resources.parser.RequestParser.__init__` requires either:
- an instance of `dict`
- a marshmallow schema

`MappingProxyType` is neither, making `RequestParser` mis-initialize

see [`RequestParser.__init__`](https://github.com/inveniosoftware/flask-resources/blob/master/flask_resources/parsers/base.py#L101)