### PR TITLE
fix: request our custom mime-type in `EditButton`

### DIFF
--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/components/EditButton.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/components/EditButton.js
@@ -1,13 +1,12 @@
-// Copyright (C) 2022-2023 Graz University of Technology.
+// Copyright (C) 2022-2024 Graz University of Technology.
 //
 // invenio-records-lom is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
-import React, { useState } from "react";
-import { Button, Icon } from "semantic-ui-react";
-import { http } from "react-invenio-forms";
-import PropTypes from "prop-types";
 import { i18next } from "@translations/invenio_records_lom/i18next";
+import React, { useState } from "react";
+import { http } from "react-invenio-forms";
+import { Button } from "semantic-ui-react";
 
 export const EditButton = ({ recid, onError, className, size, fluid }) => {
   const [loading, setLoading] = useState(false);
@@ -19,7 +18,16 @@ export const EditButton = ({ recid, onError, className, size, fluid }) => {
     console.log("editThenRedirect");
     setLoading(true);
     try {
-      await http.post(`/api/oer/${recid}/draft`);
+      await http.post(
+        `/api/oer/${recid}/draft`,
+        {},
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/vnd.inveniolom.v1+json",
+          },
+        }
+      );
       window.location = `/oer/uploads/${recid}`;
     } catch (error) {
       setLoading(false);


### PR DESCRIPTION
I missed this in the recent update to content-negotiation (i.e. negotiate our custom mime-type over `application/json`)

for some reason, `EditButton` uses Javascript's `post` method directly
(most other code uses `axios` configured with data passed to frontend instead)

this fixes clicking the following button:
the user-dashboard has a submenu *Educational Resources*
this submenu shows a list of the user's OER-uploads
those OER-upload entries show a button `Edit` in their upper-right corner

also see [this commit](https://github.com/inveniosoftware/invenio-app-rdm/commit/d4f58d3e92a78f2f94eb5998195ede19d69f4f5c) for `invenio-app-rdm`, where they change their `EditButton`'s requested mime-type