### PR TITLE
update: update deprecated `ReactDOM.render`

### DIFF
--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/index.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/index.js
@@ -5,15 +5,16 @@
 
 import { getInputFromDOM } from "@js/invenio_rdm_records";
 import React from "react"; // needs be in scope to use .jsx
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import LOMDepositForm from "./LOMDepositForm";
 
-ReactDOM.render(
+const root = createRoot(document.getElementById("lom-deposit-form"));
+
+root.render(
   <LOMDepositForm
     config={getInputFromDOM("lom-deposit-config")}
     files={getInputFromDOM("lom-deposit-files")}
     record={getInputFromDOM("lom-deposit-record")}
     permissions={getInputFromDOM("lom-deposit-record-permissions")}
-  />,
-  document.getElementById("lom-deposit-form")
+  />
 );

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/landing_page/index.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/landing_page/index.js
@@ -4,19 +4,19 @@
 // under the terms of the MIT License; see LICENSE file for more details.
 
 import React from "react"; // needs be in scope to use .jsx
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import { LOMRecordManagement } from "./LOMRecordManagement";
 
 const recordManagementElement = document.getElementById("lomRecordManagement");
 
 // TODO: use invenio's management React-component instead once they implement configurable API-urls
 if (recordManagementElement) {
-  ReactDOM.render(
+  const root = createRoot(recordManagementElement);
+  root.render(
     <LOMRecordManagement
       record={JSON.parse(recordManagementElement.dataset.record)}
       permissions={JSON.parse(recordManagementElement.dataset.permissions)}
       isDraft={JSON.parse(recordManagementElement.dataset.isDraft)}
-    />,
-    recordManagementElement
+    />
   );
 }


### PR DESCRIPTION
for react>=18, `ReactDom.render` was deprecated in favor of `createRoot`

see:
- react changelog on github: [this line](https://github.com/facebook/react/blob/main/CHANGELOG.md?plain=1#L96)
- react 18 upgrade guide: [this section](https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis)
