### PR TITLE
Update landing page

### DIFF
--- a/invenio_records_lom/resources/serializers/ui/schema.py
+++ b/invenio_records_lom/resources/serializers/ui/schema.py
@@ -232,7 +232,7 @@ class LOMUIBaseSchema(BaseObjectSchema):
         """Get DOI."""
         prefix = current_app.config["DATACITE_PREFIX"]
         pid = obj["id"]
-        return f"https://dx.doi.org/{prefix}/{pid}"
+        return f"https://doi.org/{prefix}/{pid}"
 
 
 class LOMUILinkSchema(LOMUIBaseSchema):

--- a/invenio_records_lom/services/config.py
+++ b/invenio_records_lom/services/config.py
@@ -18,6 +18,7 @@ from invenio_drafts_resources.services.records.config import (
 )
 from invenio_indexer.api import RecordIndexer
 from invenio_rdm_records.services.config import (
+    archive_download_enabled,
     has_doi,
     is_iiif_compatible,
     is_record_and_has_doi,
@@ -161,6 +162,17 @@ class LOMRecordServiceConfig(RecordServiceConfig, ConfiguratorMixin):
     # links
     links_item = MappingProxyType(
         {
+            "archive": ConditionalLink(
+                cond=is_record,
+                if_=RecordLink(
+                    "{+api}/oer/{id}/files-archive",
+                    when=archive_download_enabled,
+                ),
+                else_=RecordLink(
+                    "{+api}/oer/{id}/draft/files-archive",
+                    when=archive_download_enabled,
+                ),
+            ),
             "doi": Link(
                 "https://doi.org/{+pid_doi}",
                 when=has_doi,
@@ -231,6 +243,10 @@ class LOMDraftFilesServiceConfig(FileServiceConfig, ConfiguratorMixin):
     file_links_list = MappingProxyType(
         {
             "self": RecordLink("{+api}/oer/{id}/draft/files"),
+            "archive": RecordLink(
+                "{+api}/oer/{id}/draft/files-archive",
+                when=archive_download_enabled,
+            ),
         },
     )
 
@@ -260,7 +276,14 @@ class LOMRecordFilesServiceConfig(FileServiceConfig, ConfiguratorMixin):
         import_string=True,
     )
 
-    file_links_list = MappingProxyType({})
+    file_links_list = MappingProxyType(
+        {
+            "archive": RecordLink(
+                "{+api}/oer/{id}/files-archive",
+                when=archive_download_enabled,
+            ),
+        },
+    )
     file_links_item = MappingProxyType(
         {
             "iiif_base": FileLink(

--- a/invenio_records_lom/templates/invenio_records_lom/record.html
+++ b/invenio_records_lom/templates/invenio_records_lom/record.html
@@ -52,10 +52,10 @@
         </div>
         <div class="right floated right aligned column">
           {% if record.ui.resource_type %}
-            <span class="ui label small neutral mb-5"
+            <span class="ui label horizontal small neutral mb-5"
                   title="{{ _('Resource type') }}">{{ record.ui.resource_type | capitalize }}</span>
           {% endif %}
-          <span class="ui label small access-status {{ record.ui.access_status.id }} mb-5"
+          <span class="ui label horizontal small access-status {{ record.ui.access_status.id }} mb-5"
                 title="{{ _('Access status') }}"
                 data-tooltip="{{ record.ui.access_status.description_l10n }}"
                 data-inverted=""

--- a/invenio_records_lom/templates/invenio_records_lom/record.html
+++ b/invenio_records_lom/templates/invenio_records_lom/record.html
@@ -128,7 +128,7 @@
 {% block record_sidebar %}
   {# TODO: invenio's sidebar also has versions, keywords (OEFOS), details, and fancier export card #}
   {% if show_record_management_menu %}
-  <section id="record-manage-menu" aria-label="{{ _('Record Management') }}" class="ui grid segment rdm-sidebar">
+  <section id="record-manage-menu" aria-label="{{ _('Record Management') }}" class="ui grid segment sidebar-container rdm-sidebar">
     {# invenio also includes data-is-preview-submission-request and data-access-links-search-config#}
     <div
       class="column"
@@ -155,44 +155,46 @@
   {% endif %}
   {% include "invenio_app_rdm/records/details/side_bar/licenses.html" %}
   {% if record.ui.location %}
-    <section id="original-content" aria-label="" class="ui segment rdm-sidebar">
-      <h2 class="ui small header">{{_("Original Content")}}</h2>
-      <p>
+    <div class="sidebar-container">
+      <h2 class="ui medium top attached header mt-0">{{_("Original Content")}}</h2>
+      <p id="original-content" aria-label="" class="ui segment bottom attached rdm-sidebar">
         <a href="{{record.ui.location}}">{{record.ui.title}}</a>
       </p>
-    </section>
+    </div>
   {% endif %}
   {% if record.ui.courses %}
-    <section id="course-content" aria-label="" class="ui segment rdm-sidebar">
-      <h2 class="ui small header">{{_("Is Part of Courses")}}</h2>
-      <ul>
+    <div class="sidebar-container">
+      <h2 class="ui medium top attached header mt-0">{{_("Is Part of Courses")}}</h2>
+      <ul id="course-content" aria-label="" class="ui segment rdm-sidebar">
         {% for course in record.ui.courses %}
-        <li>{{course.title}} ({{course.version}})</li>
+        <li style="list-style-position:inside">{{course.title}} ({{course.version}})</li>
         {% endfor %}
       </ul>
-    </section>
+    </div>
   {% endif %}
   {% if record.ui.classifications %}
-    <section id="classification-content" aria-label="" class="ui segment rdm-sidebar">
-      <h2 class="ui small header">{{_("Classifications")}}</h2>
-      <ul>
+    <div class="sidebar-container">
+      <h2 class="ui medium top attached header mt-0">{{_("Classifications")}}</h2>
+      <ul id="classification-content" aria-label="" class="ui segment bottom attached rdm-sidebar">
         {% for classification in record.ui.classifications %}
-        <li>{{classification}}</li>
+        <li style="list-style-position:inside">{{classification}}</li>
         {% endfor %}
       </ul>
-    </section>
+    </div>
   {% endif %}
   {% if record.ui.doi %}
-    <section id="doi-content" aria-label="" class="ui segment rdm-sidebar">
-      <h2 class="ui small header">{{_("DOI")}}</h2>
-      <span>{{record.ui.doi}}</span>
-    </section>
+    <div class="sidebar-container">
+      <h2 class="ui medium top attached header mt-0">{{ _("DOI") }}</h2>
+      <div id="doi-content" aria-label="" class="ui segment bottom attached rdm-sidebar">
+        <span>{{record.ui.doi}}</span>
+      </div>
+    </div>
   {% endif %}
   {% if config.get("LOM_RECORD_EXPORTERS") %}
     {# if no export formats are specified, don't bother showing the box #}
-    <section id="export-record" aria-label="{{ _('Export') }}" class="ui segment rdm-sidebar exports">
-      <h2 class="ui small header">{{ _('Export') }}</h2>
-      <div class="ui celled horizontal list separated-list">
+    <div class="sidebar-container" aria-label="{{ _('Export') }}">
+      <h2 class="ui medium top attached header mt-0">{{ _('Export') }}</h2>
+      <div id="export-record" class="ui segment bottom attached exports rdm-sidebar">
         {# dynamically create the list of export formats #}
         {% for fmt, val in config.get("LOM_RECORD_EXPORTERS", {}).items() %}
           {% set name = val.get("name", fmt) %}
@@ -206,6 +208,6 @@
           </div>
         {% endfor %}
       </div>
-    </section>
+    </div>
   {% endif %}
 {% endblock record_sidebar %}

--- a/invenio_records_lom/templates/invenio_records_lom/record.html
+++ b/invenio_records_lom/templates/invenio_records_lom/record.html
@@ -210,4 +210,5 @@
       </div>
     </div>
   {% endif %}
+  {% include "invenio_app_rdm/records/details/side_bar/technical_metadata.html" %}
 {% endblock record_sidebar %}

--- a/invenio_records_lom/templates/invenio_records_lom/records/files.html
+++ b/invenio_records_lom/templates/invenio_records_lom/records/files.html
@@ -22,13 +22,15 @@
   <section id="record-files" class="rel-mt-2" aria-label="{{ _('Files') }}">
     {% if permissions.can_read_files %}
       {# record has files AND user can see files #}
-      <h2 id="files-heading">{{ _("Files") }}</h2>
       {% set files = files|order_entries %}
-      {% if files|has_previewable_files %}
-        {% set preview_file = files|select_preview_file(default_preview=record.files.default_preview) %}
-        {{ lom_preview_file_box(preview_file, pid, is_preview, record) }}
+      {% if files %}
+        <h2 id="files-heading">{{ _("Files") }}</h2>
+        {% if files|has_previewable_files %}
+          {% set preview_file = files|select_preview_file(default_preview=record.files.default_preview) %}
+          {{ lom_preview_file_box(preview_file, pid, is_preview, record) }}
+        {% endif %}
+        {{ lom_file_list_box(files, pid, is_preview, record) }}
       {% endif %}
-      {{ lom_file_list_box(files, pid, is_preview, record) }}
     {% else %}
       {# record has files BUT user cannot see files #}
       <div class="pt-0 pb-20">

--- a/invenio_records_lom/templates/invenio_records_lom/records/files.html
+++ b/invenio_records_lom/templates/invenio_records_lom/records/files.html
@@ -29,7 +29,7 @@
           {% set preview_file = files|select_preview_file(default_preview=record.files.default_preview) %}
           {{ lom_preview_file_box(preview_file, pid, is_preview, record) }}
         {% endif %}
-        {{ lom_file_list_box(files, pid, is_preview, record) }}
+        {{ lom_file_list_box(files, pid, is_preview, include_deleted, record, permissions) }}
       {% endif %}
     {% else %}
       {# record has files BUT user cannot see files #}

--- a/invenio_records_lom/templates/invenio_records_lom/records/helpers/statistics.html
+++ b/invenio_records_lom/templates/invenio_records_lom/records/helpers/statistics.html
@@ -4,7 +4,7 @@
   invenio-records-lom is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
 #}
-  <section id="record-statistics" class="ui segment rdm-sidebar">
+  <section id="record-statistics" class="ui segment sidebar-container rdm-sidebar">
     <div class="ui tiny two statistics rel-mt-1">
       {% set all_versions = record.stats.all_versions %} {% set this_version =
       record.stats.this_version %}

--- a/invenio_records_lom/templates/invenio_records_lom/records/helpers/statistics.html
+++ b/invenio_records_lom/templates/invenio_records_lom/records/helpers/statistics.html
@@ -29,4 +29,14 @@
         </div>
       </div>
     </div>
+
+    <div class="rel-mt-1 centered">
+      <div class="'content">
+        <p class="text-align-center rel-mt-1">
+          <small>
+            <a href="/help/statistics">{{ _("More info on how stats are collected...") }}</a>
+          </small>
+        </p>
+      </div>
+    </div>
   </section>

--- a/invenio_records_lom/templates/invenio_records_lom/records/macros/files.html
+++ b/invenio_records_lom/templates/invenio_records_lom/records/macros/files.html
@@ -16,6 +16,8 @@
   it was necessary to copy paste it to override the endpoint from invenio_app_rdm_records to invenio_records_lom
 #}
 
+{% from "invenio_app_rdm/records/macros/files.html" import file_list %}
+
 {%- macro preview_file(preview_endpoint, pid_value, filename, is_preview, id='preview-iframe', width='100%', height='400' ) %}
   {% if is_preview %}
     {%- set preview_url = url_for(preview_endpoint, pid_value=pid_value, filename=filename, preview=1) -%}
@@ -46,76 +48,7 @@
 {%- endmacro %}
 
 
-{%- macro file_list(
-  files,
-  pid,
-  is_preview,
-  record=None,
-  with_preview=true,
-  download_endpoint='invenio_records_lom.record_file_download',
-  preview_endpoint='invenio_records_lom.record_file_preview'
-) %}
-  <table class="ui striped table files-table">
-    <thead>
-      <tr>
-        <th>{{_('Name')}}</th>
-        <th>{{_('Size')}}</th>
-        {# TODO: invenio does archive-download here; if that were implemented for lom-records, we can use invenio's macro and remove this macro... #}
-        <th>
-          {% if config.RDM_ARCHIVE_DOWNLOAD_ENABLED %}
-            <a role:="button" class="ui compact mini button right floated archive-link" href="{{ record.links.archive }}">
-              <i class="file archive icon button" aria-hidden="true"></i>
-              {{ _("Download all") }}
-            </a>
-          {% endif %}
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for file in files %}
-        {% if is_preview %}
-          {%- set file_url_download = url_for(download_endpoint, pid_value=pid, filename=file.key, download=1, preview=1) %}
-          {%- set file_url_preview = url_for(preview_endpoint, pid_value=pid, filename=file.key, preview=1) %}
-        {% else %}
-          {%- set file_url_download = url_for(download_endpoint, pid_value=pid, filename=file.key, download=1) %}
-          {%- set file_url_preview = url_for(preview_endpoint, pid_value=pid, filename=file.key) %}
-        {% endif %}
-        {%- set file_type = file.key.split('.')[-1] %}
-        <tr>
-          <td>
-            <div class="truncated">
-              <a href="{{ file_url_download }}">{{ file.key }}</a>
-            </div>
-            <small class="ui text-muted font-tiny">
-              {{ file.checksum }}
-              <div class="ui icon inline-block" data-tooltip="{{_('This is the file fingerprint (checksum), which can be used to verify the file integrity.')}}">
-                <i class="question circle checksum icon"></i>
-              </div>
-            </small>
-          </td>
-          <td>{{ file.size|filesizeformat(binary=not config.APP_RDM_DISPLAY_DECIMAL_FILE_SIZES) }}</td>
-          <td class="right aligned">
-            <span>
-              {% if with_preview and file_type|lower is previewable %}
-              <a class="ui compact mini button preview-link" href="{{ file_url_preview }}" target="preview-iframe" data-file-key="{{file.key}}">
-                <i class="eye icon"></i>
-                {{_("Preview")}}
-              </a>
-              {% endif %}
-              <a class="ui compact mini button" href="{{ file_url_download }}" role="button">
-                <i class="download icon"></i>
-                {{_('Download')}}
-              </a>
-            </span>
-          </td>
-        </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-{%- endmacro %}
-
-
-{% macro lom_file_list_box(files, pid, is_preview, record) %}
+{% macro lom_file_list_box(files, pid, is_preview, include_deleted, record, permissions) %}
   <div id="lom-filelist-accordion" class="ui accordion panel mb-10 {{record.ui.access_status.id}}" href="#files-list-accordion-panel">
     <h3 class="active title trigger panel-heading m-0 {{record.ui.access_status.id}}" aria-label="{{ _('Files') }}">
       {{ _("Files") }}
@@ -138,7 +71,13 @@
         </div>
       {% endif %}
       <div id="collapsableFiles">
-        {{ file_list(files, pid, is_preview, record=record) }}
+        {{ file_list(
+          files, pid, is_preview, include_deleted,
+          record=record,
+          download_endpoint='invenio_records_lom.record_file_download',
+          preview_endpoint='invenio_records_lom.record_file_preview',
+          permissions=permissions,
+        ) }}
       </div>
     </div>
   </div>

--- a/invenio_records_lom/templates/invenio_records_lom/records/macros/files.html
+++ b/invenio_records_lom/templates/invenio_records_lom/records/macros/files.html
@@ -34,19 +34,15 @@
 
 
 {% macro lom_preview_file_box(file, pid, is_preview, record) %}
-<div class="">
-  <div class="ui accordion panel mb-10 {{record.ui.access_status.id}}" id="preview" href="#collapsablePreview">
-    <div class="active title trigger panel-heading {{record.ui.access_status.id}} truncated" tabindex="0" aria-label="{{ _('File preview') }}">
+  <div id="lom-filepreview-accordion" class="ui accordion panel mb-10 {{record.ui.access_status.id}}" href="#files-preview-accordion-panel">
+    <h3 class="active title trigger panel-heading truncated m-0 {{record.ui.access_status.id}}" aria-label="{{ _('File preview') }}">
       <span id="preview-file-title">{{file.key}}</span>
       <i class="ui angle right icon"></i>
-    </div>
-    <div id="collapsablePreview" class="active content pt-0">
-      <div>
-        {{ preview_file('invenio_records_lom.record_file_preview', pid_value=pid, filename=file.key, is_preview=is_preview) }}
-      </div>
+    </h3>
+    <div id="collapsablePreview" class="active conten pt-0">
+      {{ preview_file('invenio_records_lom.record_file_preview', pid_value=pid, filename=file.key, is_preview=is_preview) }}
     </div>
   </div>
-</div>
 {%- endmacro %}
 
 
@@ -112,31 +108,29 @@
 
 
 {% macro lom_file_list_box(files, pid, is_preview, record) %}
-  <div class="">
-    <div class="ui accordion panel mb-10 {{record.ui.access_status.id}}" id="preview" href="#collapsablePreview">
-      <div class="active title trigger panel-heading {{record.ui.access_status.id}}" tabindex="0">
-        {{ _("Files") }}
-        <small class="text-muted">
-          {% if files %}
-            ({{files|sum(attribute='size')|filesizeformat}})
-          {% endif %}
-        </small>
-        <i class="angle right icon"></i>
-      </div>
-      <div class="active content pt-0">
-        {% if record.access.files == 'restricted' %}
-          <div class="ui {{ record.ui.access_status.message_class }} message file-box-message">
-            <i class="ui {{ record.ui.access_status.icon }} icon"></i>
-            <b>{{ record.ui.access_status.title_l10n }}</b>
-            <p>{{ record.ui.access_status.description_l10n }}</p>
-            {% if record.access.embargo.reason %}
-              <p>{{_("Reason")}}: {{record.access.embargo.reason}}</p>
-            {% endif%}
-          </div>
+  <div id="lom-filelist-accordion" class="ui accordion panel mb-10 {{record.ui.access_status.id}}" href="#files-list-accordion-panel">
+    <h3 class="active title trigger panel-heading m-0 {{record.ui.access_status.id}}" aria-label="{{ _('Files') }}">
+      {{ _("Files") }}
+      <small class="text-muted">
+        {% if files %}
+          ({{files|sum(attribute='size')|filesizeformat}})
         {% endif %}
-        <div id="collapsableFiles">
-          {{ file_list(files, pid, is_preview) }}
+      </small>
+      <i class="angle right icon"></i>
+    </h3>
+    <div class="active content pt-0">
+      {% if record.access.files == 'restricted' %}
+        <div class="ui {{ record.ui.access_status.message_class }} message file-box-message">
+          <i class="ui {{ record.ui.access_status.icon }} icon"></i>
+          <b>{{ record.ui.access_status.title_l10n }}</b>
+          <p>{{ record.ui.access_status.description_l10n }}</p>
+          {% if record.access.embargo.reason %}
+            <p>{{_("Reason")}}: {{record.access.embargo.reason}}</p>
+          {% endif%}
         </div>
+      {% endif %}
+      <div id="collapsableFiles">
+        {{ file_list(files, pid, is_preview) }}
       </div>
     </div>
   </div>

--- a/invenio_records_lom/templates/invenio_records_lom/records/macros/files.html
+++ b/invenio_records_lom/templates/invenio_records_lom/records/macros/files.html
@@ -50,6 +50,7 @@
   files,
   pid,
   is_preview,
+  record=None,
   with_preview=true,
   download_endpoint='invenio_records_lom.record_file_download',
   preview_endpoint='invenio_records_lom.record_file_preview'
@@ -60,7 +61,14 @@
         <th>{{_('Name')}}</th>
         <th>{{_('Size')}}</th>
         {# TODO: invenio does archive-download here; if that were implemented for lom-records, we can use invenio's macro and remove this macro... #}
-        <th></th>
+        <th>
+          {% if config.RDM_ARCHIVE_DOWNLOAD_ENABLED %}
+            <a role:="button" class="ui compact mini button right floated archive-link" href="{{ record.links.archive }}">
+              <i class="file archive icon button" aria-hidden="true"></i>
+              {{ _("Download all") }}
+            </a>
+          {% endif %}
+        </th>
       </tr>
     </thead>
     <tbody>
@@ -130,7 +138,7 @@
         </div>
       {% endif %}
       <div id="collapsableFiles">
-        {{ file_list(files, pid, is_preview) }}
+        {{ file_list(files, pid, is_preview, record=record) }}
       </div>
     </div>
   </div>

--- a/invenio_records_lom/ui/records/decorators.py
+++ b/invenio_records_lom/ui/records/decorators.py
@@ -29,6 +29,17 @@ from sqlalchemy.orm.exc import NoResultFound
 from ...proxies import current_records_lom
 
 
+def pass_include_deleted[T](func: Callable[..., T]) -> Callable:
+    """Retrive `include_deleted` from request-args and pass into decorated function."""
+
+    @wraps(func)
+    def decoed(**kwargs: dict) -> T:
+        include_deleted = request.args.get("include_deleted") == "1"
+        return func(**kwargs, include_deleted=include_deleted)
+
+    return decoed
+
+
 def pass_is_oer_certified[T](func: Callable[..., T]) -> Callable:
     """Check if the logged in user has the permission to create oer's."""
 

--- a/invenio_records_lom/ui/records/records.py
+++ b/invenio_records_lom/ui/records/records.py
@@ -33,6 +33,7 @@ from ...resources.serializers import LOMToUIJSONSerializer
 from .decorators import (
     pass_file_item,
     pass_file_metadata,
+    pass_include_deleted,
     pass_is_preview,
     pass_record_files,
     pass_record_from_pid,
@@ -87,6 +88,7 @@ class PreviewFile:
 # Views
 #
 @pass_is_preview
+@pass_include_deleted
 @pass_record_or_draft
 @pass_record_files
 def record_detail(
@@ -94,6 +96,8 @@ def record_detail(
     is_preview: bool | None = None,
     record: RecordItem = None,
     files: FileList | None = None,
+    *,
+    include_deleted: bool = False,
 ) -> str:
     """Record detail page (aka landing page)."""
     files_dict = {} if files is None else files.to_dict()
@@ -113,14 +117,15 @@ def record_detail(
 
     return render_template(
         "invenio_records_lom/record.html",
-        record=record_ui,
-        pid=pid_value,
         files=files_dict,
+        include_deleted=include_deleted,
+        is_draft=is_draft,
+        is_preview=is_preview,
         permissions=record.has_permissions_to(
             ["edit", "new_version", "manage", "update_draft", "read_files", "review"],
         ),
-        is_preview=is_preview,
-        is_draft=is_draft,
+        pid=pid_value,
+        record=record_ui,
     )
 
 

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/components/EditButton.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/components/EditButton.js
@@ -9,7 +9,16 @@ import React, { useState } from "react";
 import { http } from "react-invenio-forms";
 import { Button } from "semantic-ui-react";
 
-export const EditButton = ({ recid, onError, className, size, fluid }) => {
+export const EditButton = ({
+  recid,
+  onError,
+  // the following arguments are for UI:
+  className,
+  compact,
+  floated,
+  fluid,
+  size,
+}) => {
   const [loading, setLoading] = useState(false);
 
   const editThenRedirect = async () => {
@@ -36,11 +45,12 @@ export const EditButton = ({ recid, onError, className, size, fluid }) => {
   return (
     <Button
       className={className}
-      compact
+      compact={compact}
       content={i18next.t("Edit")}
-      floated="right"
+      floated={floated}
       fluid={fluid}
       icon="edit"
+      labelPosition="left"
       loading={loading}
       onClick={() => editThenRedirect()}
       size={size}
@@ -50,6 +60,8 @@ export const EditButton = ({ recid, onError, className, size, fluid }) => {
 
 EditButton.propTypes = {
   className: PropTypes.string,
+  compact: PropTypes.bool,
+  floated: PropTypes.string,
   fluid: PropTypes.bool,
   onError: PropTypes.func.isRequired,
   recid: PropTypes.string.isRequired,
@@ -58,6 +70,8 @@ EditButton.propTypes = {
 
 EditButton.defaultProps = {
   className: null,
+  compact: false,
+  floated: null,
   fluid: false,
-  size: "small",
+  size: null,
 };

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/landing_page/index.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/landing_page/index.js
@@ -3,6 +3,7 @@
 // invenio-records-lom is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
+import $ from "jquery";
 import React from "react"; // needs be in scope to use .jsx
 import { createRoot } from "react-dom/client";
 import { LOMRecordManagement } from "./LOMRecordManagement";
@@ -20,3 +21,7 @@ if (recordManagementElement) {
     />
   );
 }
+
+// enable semantic-ui's accordion-behavior for file-preview and files-list
+$("#lom-filelist-accordion").accordion();
+$("#lom-filepreview-accordion").accordion();

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/search/components.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/search/components.js
@@ -124,7 +124,13 @@ export const LOMRecordResultsListItem = ({ result, index }) => {
               {accessStatus}
             </Label>
             <div className="ui right floated">
-              <EditButton recid={result.id} onError={handleError} />
+              <EditButton
+                recid={result.id}
+                onError={handleError}
+                compact
+                floated="right"
+                size="small"
+              />
               {error && (
                 <Label basic color="red" pointing="right">
                   {error}


### PR DESCRIPTION
through time, `invenio-records-lom`'s landing-page has drifted from `invenio-app-rdm`'s
this brings our landing-page more in line with `invenio-app-rdm` as to provide the same look and feel for all landing pages

the DOI-url change isn't to align with `invenio-app-rdm` but to fulfill DataCite's new [`DOI Display Guidelines`](https://support.datacite.org/docs/datacite-doi-display-guidelines#overview-of-changes-to-datacites-current-practices):
_"Our new Guidelines introduce three important changes that differ from previous practices:"_
_"- drop the `dx` from the domain name portion of DOI links"_


landing page before changes:
![lom_before](https://github.com/user-attachments/assets/7ed572e9-e996-4e0c-b270-cad1654d4b1c)

landing page after changes:
![lom_after](https://github.com/user-attachments/assets/4f9e81fe-0c22-4cd8-86c4-0948a0394132)

invenio-rdm's landing page for comparison:
![rdm](https://github.com/user-attachments/assets/9ab16ee0-cf13-47cf-a5e5-3850f9e24bcf)
