### PR TITLE
Revert: update deprecated `ReactDOM.render`

### DIFF
--- a/invenio_records_lom/records/systemfields/relations.py
+++ b/invenio_records_lom/records/systemfields/relations.py
@@ -37,22 +37,22 @@ class PIDLOMRelation(PIDRelation):
         self._catalog = _catalog
         super().__init__(key=key, _value_key_suffix=_value_key_suffix, **kwargs)
 
-    def parse_value(self, value) -> None:  # noqa: ANN001, ARG002
+    def parse_value(self, value) -> None:  # noqa: ANN001
         """Parse a record (or ID) to the ID to be stored."""
         msg = f"{self.__class__.__qualname__}.parse_value is not implemented yet"
         raise NotImplementedError(msg)
 
-    def set_value(self, record, value) -> None:  # noqa: ANN001, ARG002
+    def set_value(self, record, value) -> None:  # noqa: ANN001
         """Set the relation value."""
         msg = f"{self.__class__.__qualname__}.set_value is not implemented yet"
         raise NotImplementedError(msg)
 
-    def clear_value(self, record) -> bool:  # noqa: ANN001, ARG002
+    def clear_value(self, record) -> bool:  # noqa: ANN001
         """Clear the relation value."""
         msg = f"{self.__class__.__qualname__}.clear_value is not implemented yet"
         raise NotImplementedError(msg)
 
-    def exists_many(self, ids: list) -> bool:  # noqa: ARG002
+    def exists_many(self, ids: list) -> bool:
         """Check multiple existence by a list of IDs."""
         msg = f"{self.__class__.__qualname__}.exists_many is not implemented yet"
         raise NotImplementedError(msg)

--- a/invenio_records_lom/records/systemfields/results.py
+++ b/invenio_records_lom/records/systemfields/results.py
@@ -15,7 +15,7 @@ from ...utils import DotAccessWrapper
 class RelationLOMResult(RelationResult):
     """Relation access result."""
 
-    def __call__(self, *, force: bool = True) -> None:  # noqa: ARG002
+    def __call__(self, *, force: bool = True) -> None:
         """Resolve the relation."""
         msg = f"{self.__class__.__qualname__}.__call__ is not implemented yet"
         raise NotImplementedError(msg)
@@ -83,13 +83,13 @@ class RelationLOMResult(RelationResult):
         # gets called pre_commit, clears any dereferenced values before committing
         self._apply_items(self._clean_one, keys, attrs)
 
-    def append(self, value) -> None:  # noqa: ANN001, ARG002
+    def append(self, value) -> None:  # noqa: ANN001
         """Append a relation to the list."""
         # (2021-10-18): invenio raises here too
         msg = f"{self.__class__.__qualname__}.append is not implemented yet"
         raise NotImplementedError(msg)
 
-    def insert(self, index, value) -> None:  # noqa: ANN001, ARG002
+    def insert(self, index, value) -> None:  # noqa: ANN001
         """Insert a relation to the list."""
         # (2021-10-18): invenio raises here too
         msg = f"{self.__class__.__qualname__}.insert is not implemented yet"

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/index.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/index.js
@@ -5,16 +5,15 @@
 
 import { getInputFromDOM } from "@js/invenio_rdm_records";
 import React from "react"; // needs be in scope to use .jsx
-import { createRoot } from "react-dom/client";
+import ReactDOM from "react-dom";
 import LOMDepositForm from "./LOMDepositForm";
 
-const root = createRoot(document.getElementById("lom-deposit-form"));
-
-root.render(
+ReactDOM.render(
   <LOMDepositForm
     config={getInputFromDOM("lom-deposit-config")}
     files={getInputFromDOM("lom-deposit-files")}
     record={getInputFromDOM("lom-deposit-record")}
     permissions={getInputFromDOM("lom-deposit-record-permissions")}
-  />
+  />,
+  document.getElementById("lom-deposit-form")
 );

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/landing_page/index.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/landing_page/index.js
@@ -5,20 +5,20 @@
 
 import $ from "jquery";
 import React from "react"; // needs be in scope to use .jsx
-import { createRoot } from "react-dom/client";
+import ReactDOM from "react-dom";
 import { LOMRecordManagement } from "./LOMRecordManagement";
 
 const recordManagementElement = document.getElementById("lomRecordManagement");
 
 // TODO: use invenio's management React-component instead once they implement configurable API-urls
 if (recordManagementElement) {
-  const root = createRoot(recordManagementElement);
-  root.render(
+  ReactDOM.render(
     <LOMRecordManagement
       record={JSON.parse(recordManagementElement.dataset.record)}
       permissions={JSON.parse(recordManagementElement.dataset.permissions)}
       isDraft={JSON.parse(recordManagementElement.dataset.isDraft)}
-    />
+    />,
+    recordManagementElement
   );
 }
 


### PR DESCRIPTION
* This reverts commit 779a9674bbc1c1affbea37515a3fa5fc2f872b04.

* reason: the change is for react >= 18 and we are not yet there to
  upgrade
