### PR TITLE
fix: accept extra kwargs on file-download

### DIFF
--- a/invenio_records_lom/ui/records/records.py
+++ b/invenio_records_lom/ui/records/records.py
@@ -198,6 +198,7 @@ def record_file_preview(  # noqa: ANN201
 def record_file_download(  # noqa: ANN201
     file_item: FileItem = None,
     pid_value: str | None = None,  # noqa: ARG001
+    filename: str | None = None,  # noqa: ARG001
     *,
     is_preview: bool = False,  # noqa: ARG001
 ):


### PR DESCRIPTION
in particular, `filename` was passed as a kwarg,
but `record_file_download` took no such keyword argument...