### PR TITLE
fix: DOI resolution

### DIFF
--- a/invenio_records_lom/resources/serializers/ui/schema.py
+++ b/invenio_records_lom/resources/serializers/ui/schema.py
@@ -230,9 +230,8 @@ class LOMUIBaseSchema(BaseObjectSchema):
 
     def get_doi(self, obj: dict) -> str:
         """Get DOI."""
-        prefix = current_app.config["DATACITE_PREFIX"]
-        pid = obj["id"]
-        return f"https://doi.org/{prefix}/{pid}"
+        doi = obj.get("pids", {}).get("doi", {}).get("identifier", "")
+        return f"https://doi.org/{doi}"
 
 
 class LOMUILinkSchema(LOMUIBaseSchema):


### PR DESCRIPTION
records could be uploaded with external DOIs
in that case, they needn't have DATACITE_PREFIX as prefix
correct way is to get DOI from `"pids"` dict