### PR TITLE
fix: get `UTC` timezone via correct attribute-name

### DIFF
--- a/invenio_records_lom/services/tasks.py
+++ b/invenio_records_lom/services/tasks.py
@@ -38,9 +38,9 @@ def lom_reindex_stats(stats_indices: list) -> str:
     if not last_run:
         # If this is the first time that we run, let's do it for the documents
         # of the last week
-        last_run = (datetime.now(timezone.UTC) - timedelta(days=7)).isoformat()
+        last_run = (datetime.now(timezone.utc) - timedelta(days=7)).isoformat()
 
-    reindex_start_time = datetime.now(timezone.UTC).isoformat()
+    reindex_start_time = datetime.now(timezone.utc).isoformat()
     indices = ",".join(f"{prefix_index(x)}*" for x in stats_indices)
 
     all_parents = set()


### PR DESCRIPTION
either would have worked:
- `datetime.UTC` (`datetime` with upper-case `.UTC`)
- `timezone.utc` (`timezone` with lower-case `.utc`)

but we got our wires crossed and used `timezone.UTC`

this bug was introduced when moving to ruff
relevant ruff error: [DTZ005](https://docs.astral.sh/ruff/rules/call-datetime-now-without-tzinfo/)