### PR TITLE
various changes to OAI-PMH output for compatibility

### DIFF
--- a/invenio_records_lom/resources/serializers/oai/schema.py
+++ b/invenio_records_lom/resources/serializers/oai/schema.py
@@ -9,7 +9,7 @@
 
 from copy import copy
 
-from marshmallow import EXCLUDE, Schema, fields, pre_load, validate, validates_schema
+from marshmallow import EXCLUDE, Schema, fields, pre_dump, validate, validates_schema
 
 from ....services.schemas.metadata import validate_cc_license_lang
 from ....utils import make_lom_vcard
@@ -225,7 +225,7 @@ class LifecycleSchema(ExcludeUnknownOrderedSchema):
     status = fields.Field()
     contribute = fields.List(fields.Nested(ContributeSchema()))
 
-    @pre_load
+    @pre_dump
     def group_contributes_by_role(self, data: dict, **__: dict) -> dict:
         """Group contributes by role."""
         contributions_by_role = {}

--- a/invenio_records_lom/resources/serializers/oai/schema.py
+++ b/invenio_records_lom/resources/serializers/oai/schema.py
@@ -221,6 +221,7 @@ class ContributeSchema(ExcludeUnknownOrderedSchema):
 class LifecycleSchema(ExcludeUnknownOrderedSchema):
     """Schema for LOM-UIBK's `lifecycle` category."""
 
+    datetime = fields.String()
     version = fields.Field()
     status = fields.Field()
     contribute = fields.List(fields.Nested(ContributeSchema()))

--- a/invenio_records_lom/resources/serializers/oai/schema.py
+++ b/invenio_records_lom/resources/serializers/oai/schema.py
@@ -309,12 +309,12 @@ class LearningResourceTypeSchema(ExcludeUnknownOrderedSchema):
         validate=validate.Equal(LANGSTRING_KIM_HCRT_SCHEME),
         dump_default=LANGSTRING_KIM_HCRT_SCHEME,
     )
-    id = fields.Str(required=True, dump_default="N/A")
+    id = fields.Str(required=True, dump_default="https://w3id.org/kim/hcrt/other")
 
     @classmethod
     def dump_default(cls) -> dict:
         """Dump default."""
-        obj = {"id": "N/A"}
+        obj = {"id": "https://w3id.org/kim/hcrt/other"}
         obj |= {"source": LANGSTRING_KIM_HCRT_SCHEME}
         return obj
 

--- a/invenio_records_lom/services/schemas/metadata.py
+++ b/invenio_records_lom/services/schemas/metadata.py
@@ -9,6 +9,7 @@
 
 from collections.abc import Callable
 from copy import copy
+from datetime import datetime, timezone
 from types import MappingProxyType
 
 from invenio_i18n import lazy_gettext as _
@@ -23,6 +24,15 @@ from marshmallow import (
 )
 from marshmallow_utils.fields import SanitizedUnicode
 from marshmallow_utils.html import sanitize_unicode
+
+
+def now_isoformat() -> str:
+    """Return current date and time in ISO-8601 format.
+
+    example-return: '2020-06-24T05:34:56.789123'
+    """
+    now_unaware = datetime.now(timezone.utc).replace(tzinfo=None)
+    return now_unaware.isoformat()
 
 
 class NoValidationSchema(Schema):
@@ -250,6 +260,7 @@ class ContributeSchema(Schema):
 class LifecycleSchema(Schema):
     """Schema for LOM's `lifecycle` category."""
 
+    datetime = fields.String(load_default=now_isoformat)
     contribute = fields.List(
         fields.Nested(ContributeSchema()),
         required=True,


### PR DESCRIPTION
### ad `pre_dump` change
`OAISchema` is only used in serialization to `.dump` database-schemaed json to OAI-schemaed json
originally, `OAISchema` incorrectly used `.load` instead of `.dump`
this got changed in [this commit](https://github.com/tu-graz-library/invenio-records-lom/commit/7b421f1f4f83a910e71edb1365ee02de485938a7#diff-13b72c55af5f06511907a95e71621aaf5c0597ecfad90fda92a999acac0794f2R49)
when moving from `.load` to `.dump`, the commit *should also have* exchanged the incorrect `@pre_load` for `@pre_dump`, but didn't

### ad timezone-unawareness of `now_isoformat`
due to issues with timezone-awareness, datetimes are timezone-unaware for now
see [here](https://github.com/inveniosoftware/invenio-oauthclient/pull/328#discussion_r1599993184) for discussion on this