### PR TITLE
Fix DOI-redirect by ignoring extraneous parameters

### DIFF
--- a/invenio_records_lom/ui/records/records.py
+++ b/invenio_records_lom/ui/records/records.py
@@ -231,6 +231,7 @@ def record_latest(  # noqa: ANN201
 @pass_record_from_pid
 def record_from_pid(  # noqa: ANN201
     record: RecordItem = None,
+    **__,  # noqa: ANN003
 ):
     """Redirect to record's landing page."""
     return redirect(record["links"]["self_html"], code=301)

--- a/invenio_records_lom/ui/records/records.py
+++ b/invenio_records_lom/ui/records/records.py
@@ -100,6 +100,7 @@ def record_detail(
     files: FileList | None = None,
     *,
     include_deleted: bool = False,
+    **__,  # noqa: ANN003
 ) -> str:
     """Record detail page (aka landing page)."""
     files_dict = {} if files is None else files.to_dict()
@@ -139,6 +140,7 @@ def record_export(
     pid_value: str | None = None,
     *,
     is_preview: bool | None = False,  # noqa: ARG001
+    **__,  # noqa: ANN003
 ) -> tuple[dict, int, dict]:
     """Export view for LOM records."""
     exporter = current_app.config.get("LOM_RECORD_EXPORTERS", {}).get(export_format)
@@ -201,6 +203,7 @@ def record_file_download(  # noqa: ANN201
     filename: str | None = None,  # noqa: ARG001
     *,
     is_preview: bool = False,  # noqa: ARG001
+    **__,  # noqa: ANN003
 ):
     """Download a file from a record."""
     # emit a file download stats event
@@ -223,6 +226,7 @@ def record_file_download(  # noqa: ANN201
 @pass_record_latest
 def record_latest(  # noqa: ANN201
     record: RecordItem = None,
+    **__,  # noqa: ANN003
 ):
     """Redirect to record's landing page."""
     return redirect(record["links"]["self_html"], code=302)

--- a/invenio_records_lom/ui/records/records.py
+++ b/invenio_records_lom/ui/records/records.py
@@ -225,7 +225,7 @@ def record_latest(  # noqa: ANN201
     record: RecordItem = None,
 ):
     """Redirect to record's landing page."""
-    return redirect(record["links"]["self_html"], code=301)
+    return redirect(record["links"]["self_html"], code=302)
 
 
 @pass_record_from_pid
@@ -234,4 +234,4 @@ def record_from_pid(  # noqa: ANN201
     **__,  # noqa: ANN003
 ):
     """Redirect to record's landing page."""
-    return redirect(record["links"]["self_html"], code=301)
+    return redirect(record["links"]["self_html"], code=302)


### PR DESCRIPTION
### ad issue with redirecting DOI-URL
DOI-URL for OER-records is of form `<domain>/oer/doi/<INSTITUTION-CODE>/<pid>` (e.g. `my-repo.org/oer/doi/10.1234/asdfg-hjk42`)
this then gets redirected to the landing-page's URL (e.g. `my-repo.org/oer/asdfg-hjk42`)
the actual redirect is done by the view-function `record_from_pid`
this function was passed additional kwargs (which it didn't accept), causing the attempted redirect to fail

### ad changing redirect code to 302
this follows a similar upstream-change: [here](https://github.com/inveniosoftware/invenio-app-rdm/pull/2310)
apparently the redirected-to URL might change at some point
HTTP 301 *Moved Permanently* would have browsers cache the redirect forever
should the redirected-to URL change, this would result in a 404 for users...

### ad ignoring extraneous kwargs in view-functions
`pass_*` decorators pass on all their received kwargs as later `pass_*` decorators might need them
orginal kwargs come from URL-parsing, new ones might get added anytime
such new kwargs aren't ignored by view-functions, causing the call to fail
failures caused by this have been common recently
this preempts future such failures by ignoring extraneous kwargs