### PR TITLE
Update handling of `metadata.educational.learningresourcetype`

### DIFF
--- a/invenio_records_lom/fixtures/demo.py
+++ b/invenio_records_lom/fixtures/demo.py
@@ -241,7 +241,7 @@ def create_fake_educational(fake: Faker) -> dict:
 
     return {
         "interactivitytype": vocabularify(fake, interactivity_types),
-        "learningresourcetype": create_fake_learningresourcetype(fake),
+        "learningresourcetype": [create_fake_learningresourcetype(fake)],
         "interactivitylevel": vocabularify(fake, levels),
         "semanticdensity": vocabularify(fake, levels),
         "intendedenduserrole": vocabularify(fake, end_user_roles),

--- a/invenio_records_lom/resources/serializers/oai/schema.py
+++ b/invenio_records_lom/resources/serializers/oai/schema.py
@@ -322,10 +322,12 @@ class LearningResourceTypeSchema(ExcludeUnknownOrderedSchema):
 class EducationalSchema(ExcludeUnknownOrderedSchema):
     """Schema for LOM-UIBK's `educational` category."""
 
-    learningresourcetype = fields.Nested(
-        LearningResourceTypeSchema(),
-        required=True,
-        dump_default=LearningResourceTypeSchema.dump_default,
+    learningresourcetype = fields.List(
+        fields.Nested(
+            LearningResourceTypeSchema(),
+            required=True,
+            dump_default=LearningResourceTypeSchema.dump_default,
+        ),
     )
 
 

--- a/invenio_records_lom/services/schemas/metadata.py
+++ b/invenio_records_lom/services/schemas/metadata.py
@@ -352,7 +352,11 @@ class LearningResourceTypeSchema(Schema):
 class EducationalSchema(Schema):
     """Schema for LOM's `educational` category."""
 
-    learningresourcetype = fields.Nested(LearningResourceTypeSchema, required=True)
+    learningresourcetype = fields.List(
+        fields.Nested(LearningResourceTypeSchema, required=True),
+        required=True,
+        validate=validate.Length(min=1),
+    )
 
 
 class CopyrightAndOtherSchema(Schema):

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/fields.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/fields.js
@@ -132,7 +132,7 @@ export const LeftLabeledTextField = ({
           placeholder={placeholder}
           rows={rows}
           type="text"
-          value={fieldMeta.value}
+          value={fieldMeta.value || null}
         />
         {required && (
           <div className="ui corner label">

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/serializers.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/serializers.js
@@ -197,7 +197,7 @@ export class LOMDepositRecordSerializer extends DepositRecordSerializer {
 
     // deserialize resource-type
     form.resourcetype = {
-      value: _get(metadata, "educational.learningresourcetype.id", ""),
+      value: _get(metadata, "educational.learningresourcetype.0.id", ""),
     };
 
     // deserialize contributors
@@ -289,7 +289,7 @@ export class LOMDepositRecordSerializer extends DepositRecordSerializer {
 
     // serialize resource-type
     const resourcetypeUrl = _get(metadata, "form.resourcetype.value", "");
-    _set(metadata, "educational.learningresourcetype", {
+    _set(metadata, "educational.learningresourcetype.0", {
       source: {
         langstring: {
           "#text": "https://w3id.org/kim/hcrt/scheme",
@@ -364,7 +364,7 @@ export class LOMDepositRecordSerializer extends DepositRecordSerializer {
     setErrors(/^metadata\.rights\.url/, "license.value");
     setErrors(/^metadata\.technical\.format/, "format.value");
     setErrors(
-      /^metadata\.educational\.learningresourcetype\.id$/,
+      /^metadata\.educational\.learningresourcetype\.\d+\.id$/,
       "resourcetype.value"
     );
 

--- a/invenio_records_lom/upgrade_scripts/migrate_0_17_to_0_18.py
+++ b/invenio_records_lom/upgrade_scripts/migrate_0_17_to_0_18.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Graz University of Technology.
+#
+# invenio-records-lom is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Record migration script from invenio-records-lom v0.17 to v0.18.
+
+To upgrade, call the whole file from within app-context.
+(e.g. via `pipenv run invenio shell \
+           /path/to/invenio_records_lom/upgrade_scripts/migrate_0_17_to_0_18.py`)
+(e.g. via `pipenv run invenio shell \
+           $(find $(pipenv --venv)/lib/*/site-packages/invenio_records_lom \
+           -name migrate_0_17_to_0_18.py))`)
+"""
+
+from copy import deepcopy
+
+from click import secho
+from invenio_db import db
+
+from invenio_records_lom.records.api import LOMDraft, LOMRecord
+
+
+def execute_upgrade() -> None:
+    """Exceute upgrade from `invenio-records-lom` `v0.17` to `v0.18`."""
+    secho(
+        "LOM upgrade: ensuring `metadata.educational.learningresourcetype` is a list",
+        fg="green",
+    )
+
+    def get_new_json(old_json: dict) -> dict | None:
+        """Get updated json from current json.
+
+        if update is necessary, return updated JSON
+        otherwise, return `None`
+        """
+        current_learningresourcetype = (
+            old_json.get("metadata", {})
+            .get("educational", {})
+            .get("learningresourcetype")
+        )
+        if current_learningresourcetype is None:
+            # no learningresourcetype (which is allowed) - nothing to update
+            return None
+        if isinstance(current_learningresourcetype, list):
+            # already a list (which is correct) - no need to update
+            return None
+
+        # not a list-of-things but rather a thing itself - pack into list
+        new_json = deepcopy(old_json)
+        new_json["metadata"]["educational"]["learningresourcetype"] = [
+            current_learningresourcetype,
+        ]
+
+        return new_json
+
+    # update drafts
+    for draft in LOMDraft.model_cls.query.all():
+        old_json = draft.json
+        if not old_json:
+            continue  # for published/deleted drafts, json is None/empty
+
+        new_json = get_new_json(old_json)
+        if new_json is None:
+            # `None` means "no update necessary"
+            continue
+
+        draft.json = new_json
+        db.session.merge(draft)
+
+    # update records
+    for record in LOMRecord.model_cls.query.all():
+        old_json = record.json
+        if not old_json:
+            continue  # for records with new-version/embargo, json is None/empty
+
+        new_json = get_new_json(old_json)
+        if new_json is None:
+            # `None` means "no update necessary"
+            continue
+
+        record.json = new_json
+        db.session.merge(record)
+
+    db.session.commit()
+    secho(
+        "Successfully turned `metadata.educational.learningresourcetype` into a list where necessary!",
+        fg="green",
+    )
+    secho(
+        "NOTE: this only updated the SQL-database, you'll have to reindex records with opensearch",
+        fg="red",
+    )
+
+
+if __name__ == "__main__":
+    # gets executed when file is called directly, but not when imported
+    execute_upgrade()

--- a/invenio_records_lom/utils/metadata.py
+++ b/invenio_records_lom/utils/metadata.py
@@ -431,8 +431,15 @@ class LOMMetadata(BaseLOMMetadata):  # pylint: disable=too-many-public-methods
     def append_learningresourcetype(self, learningresourcetype: str) -> None:
         """Append learning resource type.
 
-        :param str learningresourcetype: A valid sub-url for `https://w3id.org/kim/hcrt/scheme`
+        :param str learningresourcetype: Either
+            - a URL within the vocabulary `https://w3id.org/kim/hcrt/scheme`
+            - a suffix such that `https://w3id.org/kim/hcrt/{suffix}` is such a URL
         """
+        # if the full url was passed, remove base_url from it
+        base_url = "https://w3id.org/kim/hcrt/"
+        if learningresourcetype.startswith(base_url):
+            learningresourcetype = learningresourcetype[len(base_url) :]
+
         labels = self.learningresourcetype_labels[learningresourcetype]
         entry = [langstringify(label, lang=lang) for lang, label in labels.items()]
         learningresourcetype_dict = {


### PR DESCRIPTION
### Update to `LOMMetadata.append_learningresourcetype`
A `learningresourcetype` is a value from [`https://w3id.org/kim/hcrt/scheme`](https://w3id.org/kim/hcrt/scheme).
e.g. `https://w3id.org/kim/hcrt/course` for courses

`LOMMetadata.append_learningresourcetype` takes a `str` which determines the `learningresourcetype` to add.
Currently, it only takes the last part of a `learningresourcetype` URL.
e.g. only `course`, not the full URL `https://w3id.org/kim/hcrt/course`

However, the full URL is often available when building metadata.
So this PR makes `LOMMetadata.append_learningresourcetype` accept the full URL `https://w3id.org/kim/hcrt/course` as its argument (just passing `course` still works too).

### Normalizing type of data in `metadata.educational.learningresourcetype`
`LOMMetadata.append_learningresourcetype` creates `metadata.educational.learningresourcetype` as a list-of-objects.
In other places, `metadata.educational.learningresourcetype` is created as an object instead...

According to [the spec](https://oer-repo.uibk.ac.at/lom/latest/#das-element-learningresourcetype), the element `learningresourcetype` *"MUST appear one or more times within the element `educational`"*.
To allow for *or more times*, `metadata.educational.learningresourcetype` has to be a list-of-objects.

So this PR contains an upgrade-script to normalize all `metadata.educational.learningresourcetype`s to be of type list-of-objects.