### PR TITLE
fix: fix quibbles from ruff 0.8.0

### DIFF
--- a/invenio_records_lom/__init__.py
+++ b/invenio_records_lom/__init__.py
@@ -14,7 +14,7 @@ from .proxies import current_records_lom
 __version__ = "0.18.0"
 
 __all__ = (
+    "InvenioRecordsLOM",
     "__version__",
     "current_records_lom",
-    "InvenioRecordsLOM",
 )

--- a/invenio_records_lom/fixtures/__init__.py
+++ b/invenio_records_lom/fixtures/__init__.py
@@ -17,6 +17,6 @@ from .demo import (
 __all__ = (
     "create_fake_data",
     "publish_fake_record",
-    "publish_fake_records",
     "publish_fake_record_over_celery",
+    "publish_fake_records",
 )

--- a/invenio_records_lom/records/systemfields/__init__.py
+++ b/invenio_records_lom/records/systemfields/__init__.py
@@ -27,8 +27,8 @@ __all__ = (
     "LOMPIDFieldContext",
     "LOMRecordIdProvider",
     "LOMResolver",
-    "ParentRecordAccessField",
-    "PIDLOMRelation",
-    "RecordAccessField",
     "LomRecordStatisticsField",
+    "PIDLOMRelation",
+    "ParentRecordAccessField",
+    "RecordAccessField",
 )

--- a/invenio_records_lom/services/__init__.py
+++ b/invenio_records_lom/services/__init__.py
@@ -17,8 +17,8 @@ from .services import LOMRecordService
 
 __all__ = (
     "LOMDraftFilesServiceConfig",
-    "LOMRecordPermissionPolicy",
     "LOMRecordFilesServiceConfig",
+    "LOMRecordPermissionPolicy",
     "LOMRecordService",
     "LOMRecordServiceConfig",
 )

--- a/invenio_records_lom/utils/__init__.py
+++ b/invenio_records_lom/utils/__init__.py
@@ -22,15 +22,15 @@ from .vcard import make_lom_vcard
 
 __all__ = (
     "DotAccessWrapper",
-    "get_learningresourcetypedict",
-    "get_oefosdict",
-    "LOMMetadata",
     "LOMCourseMetadata",
+    "LOMDuplicateRecordError",
+    "LOMMetadata",
     "LOMRecordData",
-    "make_lom_vcard",
     "build_record_unique_id",
     "check_about_duplicate",
     "create_record",
+    "get_learningresourcetypedict",
+    "get_oefosdict",
+    "make_lom_vcard",
     "update_record",
-    "LOMDuplicateRecordError",
 )

--- a/invenio_records_lom/utils/util.py
+++ b/invenio_records_lom/utils/util.py
@@ -7,7 +7,7 @@
 
 """Utilities for creation of LOM-compliant metadata."""
 
-from collections.abc import MutableMapping
+from collections.abc import Iterator, MutableMapping
 from csv import reader
 from importlib import resources
 from json import load
@@ -15,7 +15,6 @@ from pathlib import Path
 from re import compile as re_compile
 from re import sub
 from time import sleep
-from typing import Iterator
 
 from flask_principal import Identity
 from invenio_records_resources.services.base import Service

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ exclude = ["docs"]
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = [
-  "ANN101", "ANN102",
   "D203", "D211", "D212", "D213",
   "E501",
   "FA100", "FA102",


### PR DESCRIPTION
fixes issues found by `ruff`'s new version 0.8.0:
- these rules have been removed from ruff and need no longer be ignored: `ANN101`, `ANN102`
- sort contents of `__all__` (as per now stabilized rule `RUF022`)
- use `collections.abc.Iterable` for type-annotations (rather than `typing.Iterable`)

links:
- release notes of `ruff` 0.8.0: [here](https://github.com/astral-sh/ruff/releases/tag/0.8.0)