### PR TITLE
global: add new property `name` for metadata.rights

### DIFF
--- a/invenio_records_lom/fixtures/demo.py
+++ b/invenio_records_lom/fixtures/demo.py
@@ -14,6 +14,7 @@ from io import BytesIO
 from faker import Faker
 from flask import current_app
 from invenio_access.permissions import system_identity
+from invenio_i18n import gettext as _
 from invenio_records_resources.services.records.results import RecordItem
 
 from ..proxies import current_records_lom
@@ -295,23 +296,37 @@ def create_fake_learningresourcetype(fake: Faker) -> dict:
 
 def create_fake_rights(fake: Faker) -> dict:
     """Create a fake "rights"-element, compatible with LOMv1.0."""
-    urls = [
-        "https://creativecommons.org/publicdomain/zero/1.0/",
-        "https://creativecommons.org/licenses/by/4.0",
-        "https://creativecommons.org/licenses/by-sa/4.0",
-        "https://creativecommons.org/licenses/by-nd/4.0",
-        "https://creativecommons.org/licenses/by-nc/4.0",
-        "https://creativecommons.org/licenses/by-nc-sa/4.0",
-        "https://creativecommons.org/licenses/by-nc-nd/4.0",
-        "https://mit-license.org/",
-    ]
-    url = fake.random.choice(urls)
+    urls = {
+        "https://creativecommons.org/publicdomain/zero/1.0/": _(
+            "CC0 1.0 - Creative Commons CC0 1.0 Universal",
+        ),
+        "https://creativecommons.org/licenses/by/4.0/": _(
+            "CC BY 4.0 - Creative Commons Attribution 4.0 International",
+        ),
+        "https://creativecommons.org/licenses/by-sa/4.0/": _(
+            "CC BY-SA 4.0 - Creative Commons Attribution Share-Alike 4.0 International",
+        ),
+        "https://creativecommons.org/licenses/by-nd/4.0/": _(
+            "CC BY-ND 4.0 - Creative Commons Attribution No-Derivatives 4.0 International",
+        ),
+        "https://creativecommons.org/licenses/by-nc/4.0/": _(
+            "CC BY-NC 4.0 - Creative Commons Attribution Non-Commercial 4.0 International",
+        ),
+        "https://creativecommons.org/licenses/by-nc-sa/4.0/": _(
+            "CC BY-NC-SA 4.0 - Creative Commons Attribution Non-Commercial Share-Alike 4.0 International",
+        ),
+        "https://creativecommons.org/licenses/by-nc-nd/4.0/": _(
+            "CC BY-NC-ND 4.0 - Creative Commons Attribution Non-Commercial No-Derivatives 4.0 International",
+        ),
+    }
+    url, name = fake.random.choice(list(urls.items()))
     lang = "x-t-cc-url" if url.startswith("https://creativecommons.org/") else None
     return {
         "cost": vocabularify(fake, ["yes", "no"]),
         "copyrightandotherrestrictions": vocabularify(fake, ["yes", "no"]),
         "description": langstringify(fake, fake.paragraph(), lang=lang),
-        "url": fake.random.choice(urls),
+        "url": url,
+        "name": name,
     }
 
 

--- a/invenio_records_lom/resources/serializers/dublincore/schema.py
+++ b/invenio_records_lom/resources/serializers/dublincore/schema.py
@@ -54,7 +54,8 @@ class LOMToDublinCoreRecordSchema(BaseSerializerSchema):
 
     def get_rights(self, lom: LOMMetadata) -> list:
         """Get rights."""
-        return [lom.get_rights(url_only=True)]
+        params = ["url", "name"]
+        return lom.get_rights(params=params)
 
     def get_dates(self, lom: LOMMetadata) -> list:
         """Get dates."""

--- a/invenio_records_lom/services/facets.py
+++ b/invenio_records_lom/services/facets.py
@@ -10,39 +10,7 @@
 from invenio_i18n import gettext as _
 from invenio_records_resources.services.records.facets import TermsFacet
 
-
-def license_labels(keys: list) -> dict:
-    """Label licenses.
-
-    ATTENTION: # noqa
-    this should be a temporary solution. the real solution should be to fix the
-    metadata within the database.
-
-    """
-    license_mapping = {
-        "https://creativecommons.org/publicdomain/zero/1.0/": _("CC0 1.0"),
-        "https://creativecommons.org/licenses/by/4.0/": _("CC BY 4.0"),
-        "https://creativecommons.org/licenses/by-sa/4.0/": _("CC BY-SA 4.0"),
-        "https://creativecommons.org/licenses/by-nd/4.0/": _("CC BY-ND 4.0"),
-        "https://creativecommons.org/licenses/by-nc/4.0/": _("CC BY-NC 4.0"),
-        "https://creativecommons.org/licenses/by-nc-sa/4.0/": _("CC BY-NC-SA 4.0"),
-        "https://creativecommons.org/licenses/by-nc-nd/4.0/": _("CC BY-NC-ND 4.0"),
-    }
-    out = {}
-    for key in keys:
-        search_key = key
-        if search_key[-1] != "/":
-            search_key += "/"
-        if search_key[0:5] == "http:":
-            search_key = f"https{search_key[4:]}"
-
-        out[key] = license_mapping.get(search_key)
-
-    return out
-
-
 rights_license = TermsFacet(
-    field="metadata.rights.url.keyword",
+    field="metadata.rights.name.keyword",
     label=_("License"),
-    value_labels=license_labels,
 )

--- a/invenio_records_lom/services/schemas/metadata.py
+++ b/invenio_records_lom/services/schemas/metadata.py
@@ -391,6 +391,10 @@ class RightsSchema(Schema):
         required=True,
         validate=validate.Length(min=1, error=_("Missing data for required field.")),
     )
+    name = SanitizedUnicode(
+        required=True,
+        validate=validate.Length(min=1, error=_("Missing data for required field.")),
+    )
 
 
 class TaxonSchema(Schema):

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/fields.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/fields.js
@@ -240,7 +240,7 @@ const InnerDropdownField = ({
   const [fieldProps, fieldMeta, fieldHelpers] = useField(`${fieldPath}.value`);
 
   // get general formik-context shared by all fields
-  const { isSubmitting } = useFormikContext();
+  const { isSubmitting, setFieldValue } = useFormikContext();
 
   // get associated vocabulary from redux
   const vocabulary = useSelector((state) =>
@@ -269,7 +269,15 @@ const InnerDropdownField = ({
       name={fieldPath}
       noResultsMessage={i18next.t("No results found.")}
       onBlur={fieldProps.onBlur}
-      onChange={(e, { value }) => fieldHelpers.setValue(value)}
+      onChange={(e, { value }) => {
+        // Set the value and the name for the vocabulary
+        fieldHelpers.setValue(value);
+
+        const selectedVocabulary = vocabulary[value];
+        if (selectedVocabulary) {
+          setFieldValue(`${fieldPath}.name`, selectedVocabulary.name);
+        }
+      }}
       options={options}
       placeholder={placeholder}
       search

--- a/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/serializers.js
+++ b/invenio_records_lom/ui/theme/assets/semantic-ui/js/invenio_records_lom/deposit/serializers.js
@@ -261,6 +261,8 @@ export class LOMDepositRecordSerializer extends DepositRecordSerializer {
 
     // serialize license
     const licenseUrl = _get(metadata, "form.license.value", "");
+    const licenseName = _get(metadata, "form.license.name", "");
+
     const licenseInnerLangstring = { "#text": licenseUrl };
     if (licenseUrl.startsWith("https://creativecommons.org/")) {
       licenseInnerLangstring["lang"] = "x-t-cc-url";
@@ -274,6 +276,7 @@ export class LOMDepositRecordSerializer extends DepositRecordSerializer {
       description: {
         langstring: licenseInnerLangstring,
       },
+      name: licenseName,
     });
 
     // serialize format

--- a/invenio_records_lom/upgrade_scripts/migrate_0_19_to_0_20.py
+++ b/invenio_records_lom/upgrade_scripts/migrate_0_19_to_0_20.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 Graz University of Technology.
+#
+# invenio-records-lom is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Record migration script from invenio-records-lom v0.19 to v0.20.
+
+To upgrade, call the whole file from within app-context.
+(e.g. via `pipenv run invenio shell \
+           /path/to/invenio_records_lom/upgrade_scripts/migrate_0_19_to_0_20.py`)
+(e.g. via `pipenv run invenio shell \
+           $(find $(pipenv --venv)/lib/*/site-packages/invenio_records_lom \
+           -name migrate_0_19_to_0_20.py))`)
+"""
+
+from copy import deepcopy
+
+from click import secho
+from invenio_db import db
+from invenio_i18n import gettext as _
+
+from invenio_records_lom.records.api import LOMDraft, LOMRecord
+
+
+def execute_upgrade() -> None:  # noqa: C901
+    """Exceute upgrade from `invenio-records-lom` `v0.19` to `v0.20`."""
+    secho(
+        "LOM upgrade: ensuring `metadata.rights` has correct `name` property",
+        fg="green",
+    )
+
+    def get_new_json(old_json: dict) -> dict | None:
+        """Get updated json from current json.
+
+        if update is necessary, return updated JSON
+        otherwise, return `None`
+        """
+        license_vocabulary = {
+            "https://creativecommons.org/publicdomain/zero/1.0/": {
+                "name": "CC0 1.0 - Creative Commons CC0 1.0 Universal",
+            },
+            "https://creativecommons.org/licenses/by/4.0/": {
+                "name": _("CC BY 4.0 - Creative Commons Attribution 4.0 International"),
+            },
+            "https://creativecommons.org/licenses/by-nc/4.0/": {
+                "name": _(
+                    "CC BY-NC 4.0 - Creative Commons Attribution Non-Commercial 4.0 International",
+                ),
+            },
+            "https://creativecommons.org/licenses/by-nc-nd/4.0/": {
+                "name": _(
+                    "CC BY-NC-ND 4.0 - Creative Commons Attribution Non-Commercial No-Derivatives 4.0 International",
+                ),
+            },
+            "https://creativecommons.org/licenses/by-nc-sa/4.0/": {
+                "name": _(
+                    "CC BY-NC-SA 4.0 - Creative Commons Attribution Non-Commercial Share-Alike 4.0 International",
+                ),
+            },
+            "https://creativecommons.org/licenses/by-nd/4.0/": {
+                "name": _(
+                    "CC BY-ND 4.0 - Creative Commons Attribution No-Derivatives 4.0 International",
+                ),
+            },
+            "https://creativecommons.org/licenses/by-sa/4.0/": {
+                "name": _(
+                    "CC BY-SA 4.0 - Creative Commons Attribution Share-Alike 4.0 International",
+                ),
+            },
+            # some seem 2 times, but this is because the lack of final slash character ("/") - demo data from v0.19
+            "https://creativecommons.org/licenses/by/4.0": {
+                "name": _("CC BY 4.0 - Creative Commons Attribution 4.0 International"),
+            },
+            "https://creativecommons.org/licenses/by-nc/4.0": {
+                "name": _(
+                    "CC BY-NC 4.0 - Creative Commons Attribution Non-Commercial 4.0 International",
+                ),
+            },
+            "https://creativecommons.org/licenses/by-nc-nd/4.0": {
+                "name": _(
+                    "CC BY-NC-ND 4.0 - Creative Commons Attribution Non-Commercial No-Derivatives 4.0 International",
+                ),
+            },
+            "https://creativecommons.org/licenses/by-nc-sa/4.0": {
+                "name": _(
+                    "CC BY-NC-SA 4.0 - Creative Commons Attribution Non-Commercial Share-Alike 4.0 International",
+                ),
+            },
+            "https://creativecommons.org/licenses/by-nd/4.0": {
+                "name": _(
+                    "CC BY-ND 4.0 - Creative Commons Attribution No-Derivatives 4.0 International",
+                ),
+            },
+            "https://creativecommons.org/licenses/by-sa/4.0": {
+                "name": _(
+                    "CC BY-SA 4.0 - Creative Commons Attribution Share-Alike 4.0 International",
+                ),
+            },
+            "https://mit-license.org/": {"name": _("MIT License")},
+        }
+
+        property_to_add = "name"
+        current_rights = old_json.get("metadata", {}).get("rights", {})
+        if current_rights is None:
+            # no rights - nothing to update
+            return None
+        if property_to_add in current_rights:
+            # property already there - no need to update
+            return None
+
+        # add title from license vocabulary
+        new_json = deepcopy(old_json)
+        try:
+            new_json["metadata"]["rights"]["name"] = license_vocabulary[
+                old_json["metadata"]["rights"]["url"]
+            ]["name"]
+        except KeyError:
+            new_json["metadata"]["rights"]["name"] = "Other"
+
+        return new_json
+
+    # update drafts
+    for draft in LOMDraft.model_cls.query.all():
+        old_json = draft.json
+        if not old_json:
+            continue  # for published/deleted drafts, json is None/empty
+
+        new_json = get_new_json(old_json)
+        if new_json is None:
+            # `None` means "no update necessary"
+            continue
+
+        draft.json = new_json
+        db.session.merge(draft)
+
+    # update records
+    for record in LOMRecord.model_cls.query.all():
+        old_json = record.json
+        if not old_json:
+            continue  # for records with new-version/embargo, json is None/empty
+
+        new_json = get_new_json(old_json)
+        if new_json is None:
+            # `None` means "no update necessary"
+            continue
+
+        record.json = new_json
+        db.session.merge(record)
+
+    db.session.commit()
+    secho(
+        "Successfully added `name` to `metadata.rights` where necessary!",
+        fg="green",
+    )
+    secho(
+        "NOTE: this only updated the SQL-database, you'll have to reindex records with opensearch",
+        fg="red",
+    )
+
+
+if __name__ == "__main__":
+    # gets executed when file is called directly, but not when imported
+    execute_upgrade()

--- a/invenio_records_lom/utils/metadata.py
+++ b/invenio_records_lom/utils/metadata.py
@@ -522,16 +522,16 @@ class LOMMetadata(BaseLOMMetadata):  # pylint: disable=too-many-public-methods
             "description": langstringify(url, lang=lang),
         }
 
-    def get_rights(self, *, url_only: bool = False) -> dict | str:
+    def get_rights(self, *, params: list[str] | None = None) -> dict | list:
         """Get rights."""
         if "rights" not in self.record:
-            return "" if url_only else {}
+            return [""] if params else {}
 
-        if url_only:
+        if params:
             try:
-                return self.record["rights.url"]
+                return [self.record[f"rights.{param}"] for param in params]
             except KeyError:
-                return ""
+                return [""]
 
         return self.record["rights"]
 


### PR DESCRIPTION
- add requiered **name** field in RightsSchema
- change demo data for rights to match the license vocabulary in the deposit form
- add migration script for the new property
- update LOMMetadata and LOMToDublinCoreSchema
- remove hardcoded facets