### PR TITLE
fix(metadata): wrong return type

### DIFF
--- a/invenio_records_lom/utils/metadata.py
+++ b/invenio_records_lom/utils/metadata.py
@@ -464,7 +464,7 @@ class LOMMetadata(BaseLOMMetadata):  # pylint: disable=too-many-public-methods
         try:
             entry = self.record["educational.learningresourcetype.0.entry"]
         except KeyError:
-            return ""
+            return [""]
 
         if text_only:
             return [get_text(item) for item in entry]


### PR DESCRIPTION
* on saving the record the serialization to global-search was
  broken due to the wrong return type which caused a failure
  on the saving process.
* repair functionality for publishing OER 