### PR TITLE
Customizeable email adresses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@
 Changes
 =======
 
+Version v0.20.1 (released 2026-04-14)
+
+- fix(landingpage): correct link typo
+- fix(doi): add missing endpoint link
+
 Version v0.20.0 (released 2026-02-08)
 
 - chore(mypy): resolve error/warning

--- a/invenio_records_lom/__init__.py
+++ b/invenio_records_lom/__init__.py
@@ -11,7 +11,7 @@
 from .ext import InvenioRecordsLOM
 from .proxies import current_records_lom
 
-__version__ = "0.20.0"
+__version__ = "0.20.1"
 
 __all__ = (
     "InvenioRecordsLOM",

--- a/invenio_records_lom/config.py
+++ b/invenio_records_lom/config.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020-2024 Graz University of Technology.
+# Copyright (C) 2026 BOKU University.
 #
 # invenio-records-lom is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -403,3 +404,22 @@ LOM_CITATION_STYLES = [
 
 LOM_CITATION_STYLES_DEFAULT = "apa"
 """Default citation style."""
+
+
+# Contact references on not-licensed webformular
+# ==============================================
+
+LOM_SUPPORT_EMAIL = "telucation@tugraz.at"
+"""Shown as contact-email on not-licensed page."""
+
+LOM_SUPPORT_NUMBER = "+43(316)873-8577"
+"""Shown as contact-number on not-licensed page."""
+
+LOM_HOST_INSTITUTE = "Graz University of Technology"
+"""Host institution of educational resources"""
+
+LOM_HOST_CAMPUS = "TUGRAZonline"
+"""shown as host'S campus management system on not-licensed-page"""
+
+LOM_HOME_CAMPUS_URL = "online.tugraz.at"
+"""URL of host's campus management system""" 

--- a/invenio_records_lom/config.py
+++ b/invenio_records_lom/config.py
@@ -410,16 +410,16 @@ LOM_CITATION_STYLES_DEFAULT = "apa"
 # ==============================================
 
 LOM_SUPPORT_EMAIL = "telucation@tugraz.at"
-"""Shown as contact-email on not-licensed page."""
+"""Shown as contact-email on not-licensed-text template."""
 
 LOM_SUPPORT_NUMBER = "+43(316)873-8577"
-"""Shown as contact-number on not-licensed page."""
+"""Shown as contact-number on not-licensed-text template."""
 
 LOM_HOST_INSTITUTE = "Graz University of Technology"
-"""Host institution of educational resources"""
+"""Host institution of educational resources."""
 
 LOM_HOST_CAMPUS = "TUGRAZonline"
-"""shown as host'S campus management system on not-licensed-page"""
+"""Shown as host'S campus management system on not-licensed-text template."""
 
-LOM_HOME_CAMPUS_URL = "online.tugraz.at"
-"""URL of host's campus management system""" 
+LOM_HOST_CAMPUS_URL = "https://online.tugraz.at"
+"""URL of host's campus management system."""

--- a/invenio_records_lom/resources/config.py
+++ b/invenio_records_lom/resources/config.py
@@ -73,6 +73,8 @@ class LOMRecordResourceConfig(RecordResourceConfig, ConfiguratorMixin):
             "item-draft": "/<pid_value>/draft",
             "item-publish": "/<pid_value>/draft/actions/publish",
             "user-prefix": "/user",
+            # PIDs
+            "item-pids-reserve": "/<pid_value>/draft/pids/<scheme>",
         },
     )
 

--- a/invenio_records_lom/resources/resources.py
+++ b/invenio_records_lom/resources/resources.py
@@ -37,6 +37,7 @@ class LOMRecordResource(RDMRecordResource):
             route("PUT", prefix(routes["item-draft"]), self.update_draft),
             # User Dashboard routes
             route("GET", s(routes["user-prefix"]), self.search_user_records),
+            route("POST", prefix(routes["item-pids-reserve"]), self.pids_reserve),
         ]
 
     # TODO: some parent-methods have @response_header_signposting,

--- a/invenio_records_lom/services/config.py
+++ b/invenio_records_lom/services/config.py
@@ -290,7 +290,7 @@ class LOMRecordFilesServiceConfig(FileServiceConfig, ConfiguratorMixin):
                 params=["pid_value", "key"],
             ),
             "iiif_base": EndpointLink(
-                "lomiiif.base",
+                "lom_iiif.base",
                 params=["uuid"],
                 when=is_iiif_compatible,
                 vars=lambda file_drafcord, var_s: var_s.update(

--- a/invenio_records_lom/services/config.py
+++ b/invenio_records_lom/services/config.py
@@ -206,6 +206,11 @@ class LOMRecordServiceConfig(RecordServiceConfig, ConfiguratorMixin):
                 if_=RecordEndpointLink("invenio_records_lom.record_detail"),
                 else_=RecordEndpointLink("invenio_records_lom.deposit_edit"),
             ),
+            "reserve_doi": RecordEndpointLink(
+                "lom_records.pids_reserve",
+                params=["pid_value", "scheme"],
+                vars=lambda _, vars_: vars_.update({"scheme": "doi"}),
+            ),
         },
     )
 

--- a/invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html
+++ b/invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html
@@ -1,6 +1,7 @@
 {# -*- coding: utf-8 -*-
 
   Copyright (C) 2023 Graz University of Technology.
+  Copyright (C) 2026 BOKU University.
 
   invenio-records-lom is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -26,41 +27,46 @@
       <h1>{{_("Open Educational Resources")}}</h1>
 
       <p>
-        {{_('"Open Educational Resources (OER) are open educational materials, i.e. teaching and learning materials that
+        {{ _('"Open Educational Resources (OER) are open educational materials, i.e. teaching and learning materials that
         are freely accessible and, thanks to appropriate licensing (or because they are in the public domain), may be
         edited, further developed and distributed without additional permission."')}}
       </p>
 
-      <p>{{_("Bündnis Freie Bildung, 2015")}}</p>
+      <p>{{ _("Bündnis Freie Bildung, 2015")}}</p>
 
       <h3>{{_("Permission required!")}}</h3>
 
       <p>
-        {{_('Here you can upload your openly licensed teaching and learning materials (Open Educational Resources, OER for
+        {{ _("Here you can upload your openly licensed teaching and learning materials (Open Educational Resources, OER for
         short). By doing this, you can archive them sustainably and make them publicly accessible and usable to others.
-        Furthermore, all open educational resources uploaded here are automatically transferred to <a href="oerhub.at">OERhub.at</a> - a
-        national search engine for OER - in order to reach an even greater audience reach.')}}
+        Furthermore, all open educational resources uploaded here are automatically transferred to <a href='https://www.oerhub.at'>OERhub.at</a> - a
+        national search engine for OER - in order to reach an even greater audience reach.")}}
       </p>
 
       <p style="font-weight: bold">
-        {{_('To use the upload feature, have your account activated by sending your OER certificate issued by the national
-        certification body to <a href="mailto:telucation@tugraz.at">telucation@tugraz.at</a>.')}}
+        {{ (_("To use the upload feature, have your account activated by sending your OER certificate issued by the national 
+        certification body to <a href='mailto:{support_email}'>our OER support</a>.")
+        .format(support_email=config.LOM_SUPPORT_EMAIL)) | safe }}
       </p>
 
       <p>
-        {{_('Not yet certified? Members of Graz University of Technology are required to obtain the OER certificate from
-        fnma at Graz University of Technology, which you can obtain as part of the in-house training. Please register
-        via your business card in <a href="online.tugraz.at">TUGRAZonline</a>.')}}
+        {{ (_("Not yet certified? Members of {host_institute} are required to obtain the OER certificate from
+        fnma at {host_institute}, which you can obtain as part of the in-house training. Please register
+        via your business card in <a href='{campus_url}'>{host_campus}</a>.")
+        .format(host_institute=config.LOM_HOST_INSTITUTE, host_campus=config.LOM_HOST_CAMPUS, campus_url=config.LOM_HOST_CAMPUS_URL)) | safe }}
       </p>
 
       <p>
-        {{_('As a member of another university, visit the information page on OER certification to find a corresponding
-        offer at your university and submit your certificate to <a href="mailto:telucation@tugraz.at">telucation@tugraz.at</a>,
-        after which an upload is possible.')}}
+        {{ (_("As a member of another university, visit the information page on OER certification to find a corresponding
+        offer at your university and submit your certificate to <a href='mailto:{support_email}'>our OER support</a>,
+        after which an upload is possible."
+        ).format(support_email=config.LOM_SUPPORT_EMAIL)) | safe }}
       </p>
 
       <p>
-        {{_('For further information, please contact the OU Educational Technology directly at +43(316)873-8577 or write an email to <a href="mailto:telucation@tugraz.at">telucation@tugraz.at</a>.')}}
+        {{ (_("For further information, please contact the OU Educational Technology directly at {support_number} 
+        or write an email to <a href='mailto:{support_email}'>our OER support</a>."
+        ).format(support_email=config.LOM_SUPPORT_EMAIL, support_number=config.LOM_SUPPORT_NUMBER)) | safe }}
       </p>
     </div>
   </div>

--- a/invenio_records_lom/translations/de/LC_MESSAGES/messages.po
+++ b/invenio_records_lom/translations/de/LC_MESSAGES/messages.po
@@ -1,105 +1,170 @@
-# Translations template for invenio_records_lom.
+# German (Austria) translations for invenio_records_lom.
 # Copyright (C) 2022 Graz University of Technology
+# Copyright (C) 2026 BOKU University
 # This file is distributed under the same license as the invenio_records_lom
 # project.
-#  <christoph.ladurner@tugraz.at>, 2022.
+# <christoph.ladurner@tugraz.at>, 2022.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio_records_lom 0.1.0\n"
 "Report-Msgid-Bugs-To: info@tugraz.at\n"
-"POT-Creation-Date: 2023-12-06 11:08+0100\n"
+"POT-Creation-Date: 2026-04-15 09:26+0200\n"
 "PO-Revision-Date: 2023-12-06 11:25+0100\n"
 "Last-Translator: christoph.ladurner@tugraz.at\n"
-"Language-Team: Deutsch\n"
 "Language: de_AT\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Deutsch\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Generated-By: Babel 2.9.1\n"
-"X-Generator: Poedit 2.3.1\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
-#: invenio_records_lom/config.py:42
+#: invenio_records_lom/config.py:49
 msgid "Best match"
 msgstr ""
 
-#: invenio_records_lom/config.py:46
+#: invenio_records_lom/config.py:53
 msgid "Newest"
 msgstr ""
 
-#: invenio_records_lom/config.py:85
+#: invenio_records_lom/config.py:57
+msgid "Most viewed"
+msgstr ""
+
+#: invenio_records_lom/config.py:61
+#, fuzzy
+msgid "Most downloaded"
+msgstr "Meisten Downloads"
+
+#: invenio_records_lom/config.py:105
 msgid "JSON"
 msgstr "JSON"
 
-#: invenio_records_lom/config.py:117 invenio_records_lom/config.py:124
-#: invenio_records_lom/config.py:148
-#: invenio_records_lom/templates/invenio_records_lom/record.html:184
+#: invenio_records_lom/config.py:137 invenio_records_lom/config.py:144
+#: invenio_records_lom/config.py:168
+#: invenio_records_lom/templates/invenio_records_lom/record.html:187
 msgid "DOI"
 msgstr "DOI"
 
-#: invenio_records_lom/config.py:129
+#: invenio_records_lom/config.py:149
 msgid "OAI ID"
 msgstr "OAI ID"
 
-#: invenio_records_lom/config.py:155
+#: invenio_records_lom/config.py:175
 msgid "OAI"
 msgstr "OAI"
 
-#: invenio_records_lom/services/facets.py:22
-msgid "CC BY 4.0"
+#: invenio_records_lom/config.py:396
+msgid "APA"
 msgstr ""
 
+#: invenio_records_lom/config.py:397
+msgid "Chicago"
+msgstr ""
+
+#: invenio_records_lom/config.py:398
+msgid "IEEE"
+msgstr ""
+
+#: invenio_records_lom/config.py:399
+msgid "Harvard"
+msgstr ""
+
+#: invenio_records_lom/config.py:400
+msgid "MLA"
+msgstr ""
+
+#: invenio_records_lom/config.py:401
+msgid "Vancouver"
+msgstr ""
+
+#: invenio_records_lom/ext.py:163
+msgid "Educational Resources"
+msgstr "Bildungsinhalte"
+
 #: invenio_records_lom/services/facets.py:23
-msgid "CC BY-SA 4.0"
+msgid "CC0 1.0"
 msgstr ""
 
 #: invenio_records_lom/services/facets.py:24
-msgid "CC BY-ND 4.0"
+msgid "CC BY 4.0"
 msgstr ""
 
 #: invenio_records_lom/services/facets.py:25
-msgid "CC BY-NC 4.0"
+msgid "CC BY-SA 4.0"
 msgstr ""
 
 #: invenio_records_lom/services/facets.py:26
-msgid "CC BY-NC-SA 4.0"
+msgid "CC BY-ND 4.0"
 msgstr ""
 
 #: invenio_records_lom/services/facets.py:27
+msgid "CC BY-NC 4.0"
+msgstr ""
+
+#: invenio_records_lom/services/facets.py:28
+msgid "CC BY-NC-SA 4.0"
+msgstr ""
+
+#: invenio_records_lom/services/facets.py:29
 msgid "CC BY-NC-ND 4.0"
 msgstr ""
 
-#: invenio_records_lom/services/facets.py:44
+#: invenio_records_lom/services/facets.py:46
 msgid "License"
 msgstr ""
 
-#: invenio_records_lom/services/pids.py:52
+#: invenio_records_lom/services/pids.py:68
 msgid "Missing publisher."
+msgstr ""
+
+#: invenio_records_lom/services/schemas/metadata.py:64
+#: invenio_records_lom/services/schemas/metadata.py:319
+#: invenio_records_lom/services/schemas/metadata.py:348
+#: invenio_records_lom/services/schemas/metadata.py:392
+msgid "Missing data for required field."
+msgstr ""
+
+#: invenio_records_lom/services/schemas/metadata.py:250
+msgid "Name cannot be empty."
+msgstr ""
+
+#: invenio_records_lom/services/schemas/metadata.py:293
+msgid "Must provide at least one author and one publisher."
+msgstr ""
+
+#: invenio_records_lom/services/schemas/metadata.py:296
+msgid "Must provide at least one author."
+msgstr ""
+
+#: invenio_records_lom/services/schemas/metadata.py:299
+msgid "Must provide at least one publisher."
+msgstr ""
+
+#: invenio_records_lom/services/schemas/metadata.py:403
+msgid "Not a valid OEFOS-url."
+msgstr ""
+
+#: invenio_records_lom/services/schemas/metadata.py:447
+msgid "Must add at least one OEFOS."
 msgstr ""
 
 #: invenio_records_lom/services/schemas/records.py:33
 msgid "Persistent identifier scheme unknown to LOM."
 msgstr "Persistent identifier scheme unknown to LOM."
 
-#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:12
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:13
 #: invenio_records_lom/templates/invenio_records_lom/uploads.html:14
 msgid "OER Uploads"
 msgstr ""
 
-#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:26
-msgid "Open Educational Resources"
-msgstr "Open Educational Resources"
-
-#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:29
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:27
 #, fuzzy
-#| msgid ""
-#| "Open Educational Resources (OER) are open educational materials, i.e. "
-#| "teaching and learning materials that\n"
-#| "        are freely accessible and, thanks to appropriate licensing (or "
-#| "because they are in the public domain), may be\n"
-#| "        edited, further developed and distributed without additional "
-#| "permission."
+msgid "Open Educational Resources"
+msgstr "Öffentliche Bildungsinhalte"
+
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:30
 msgid ""
 "\"Open Educational Resources (OER) are open educational materials, i.e. "
 "teaching and learning materials that\n"
@@ -110,100 +175,97 @@ msgid ""
 msgstr ""
 "\"Open Educational Resources (OER) sind freie Bildungsmaterialien, d.h. "
 "Lehr- und Lernmaterialien,\n"
-"        die frei zugänglich sind und dank entsprechender Lizenzierung (oder "
-"weil sie gemeinfrei sind) ohne\n"
-"        zusätzliche Erlaubnis bearbeitet, weiterentwickelt und weitergegeben "
-"werden dürfen.\""
+"        die frei zugänglich sind und dank entsprechender Lizenzierung "
+"(oder weil sie gemeinfrei sind) ohne\n"
+"        zusätzliche Erlaubnis bearbeitet, weiterentwickelt und "
+"weitergegeben werden dürfen.\""
 
-#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:34
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:35
 msgid "Bündnis Freie Bildung, 2015"
 msgstr "Bündnis Freie Bildung, 2015"
 
-#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:36
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:37
 msgid "Permission required!"
 msgstr "Freigabe erforderlich!"
 
-#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:39
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:40
 msgid ""
 "Here you can upload your openly licensed teaching and learning materials "
 "(Open Educational Resources, OER for\n"
 "        short). By doing this, you can archive them sustainably and make "
 "them publicly accessible and usable to others.\n"
 "        Furthermore, all open educational resources uploaded here are "
-"automatically transferred to <a href=\"oerhub.at\">OERhub.at</a> - a\n"
-"        national search engine for OER - in order to reach an even greater "
-"audience reach."
+"automatically transferred to <a "
+"href='https://www.oerhub.at'>OERhub.at</a> - a\n"
+"        national search engine for OER - in order to reach an even "
+"greater audience reach."
 msgstr ""
 "Hier können Sie Ihre offen lizenzierten Lehr- und Lernmaterialien (Open "
 "Educational Resources, kurz OER)\n"
 "        hochladen und sie damit einerseits nachhaltig archivieren und "
 "anderseits öffentlich zugänglich und nutzbar machen.\n"
 "        Weiters werden die hier hochgeladenen offenen Bildungsressourcen "
-"automatisch an den <a href=\"oerhub.at\">OERhub.at</a> - eine nationale "
-"Suchmaschine für OER -\n"
+"automatisch an den <a href='https://www.oerhub.at'>OERhub.at</a> - eine "
+"nationale Suchmaschine für OER -\n"
 "        übertragen, um eine noch größere Reichweite zu erzielen."
 
-#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:46
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:47
+#, python-brace-format
 msgid ""
-"To use the upload feature, have your account activated by sending your OER "
-"certificate issued by the national\n"
-"        certification body to <a href=\"mailto:telucation@tugraz."
-"at\">telucation@tugraz.at</a>."
+"To use the upload feature, have your account activated by sending your "
+"OER certificate issued by the national \n"
+"        certification body to <a href='mailto:{support_email}'>our OER "
+"support</a>."
 msgstr ""
-"Um die Upload-Funktion nutzen zu können, lassen Sie sich freischalten, indem "
-"Sie Ihr OER-Zertifikat „OER Practitioner\n"
-"        | OER-Praktiker:in“ der nationalen Zertifizierungsstelle an <a "
-"href=\"mailto:telucation@tugraz.at\">telucation@tugraz.at</a>\n"
-"        schicken."
+"Um die Upload-Funktion nutzen zu können, lassen Sie sich freischalten, "
+"indem Sie Ihr OER-Zertifikat „OER Practitioner | OER-Praktiker:in“ der "
+"nationalen Zertifizierungsstelle an <a "
+"href='mailto:{support_email}'>unseren OER Support</a> schicken."
 
-#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:51
-#, fuzzy
-#| msgid ""
-#| "Not yet certified? Members of Graz University of Technology are required "
-#| "to obtain the OER certificate from\n"
-#| "        fnma at Graz University of Technology, which you can obatin as "
-#| "part of the in-house training. Please register\n"
-#| "        via your business card in <a href=\"online.tugraz."
-#| "at\">TUGRAZonline</a>."
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:53
+#, python-brace-format
 msgid ""
-"Not yet certified? Members of Graz University of Technology are required to "
-"obtain the OER certificate from\n"
-"        fnma at Graz University of Technology, which you can obtain as part "
-"of the in-house training. Please register\n"
-"        via your business card in <a href=\"online.tugraz.at\">TUGRAZonline</"
-"a>."
+"Not yet certified? Members of {host_institute} are required to obtain the"
+" OER certificate from\n"
+"        fnma at {host_institute}, which you can obtain as part of the in-"
+"house training. Please register\n"
+"        via your business card in <a "
+"href='{campus_url}'>{host_campus}</a>."
 msgstr ""
-"Noch nicht zertifiziert? Angehörige der TU Graz können das Zertifikat durch "
-"Teilnahme bei der der internen\n"
-"        Weiterbildung  OER-Zertifikats von fnma bei der TU Graz  erlangen. "
-"Bitte melden Sie sich über Ihre Visitenkarte im\n"
-"        TUGRAZonline dazu an."
+"Noch nicht zertifiziert? Angehörige der {host_institute} können das "
+"Zertifikat durch Teilnahme bei der der internen\n"
+"        Weiterbildung  OER-Zertifikats von fnma bei der {host_institute} "
+"erlangen. Bitte melden Sie sich über Ihre Visitenkarte im\n"
+"        <a \"href='{campus_url}'>{host_campus}</a> dazu an"
 
-#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:57
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:60
+#, python-brace-format
 msgid ""
 "As a member of another university, visit the information page on OER "
 "certification to find a corresponding\n"
 "        offer at your university and submit your certificate to <a "
-"href=\"mailto:telucation@tugraz.at\">telucation@tugraz.at</a>,\n"
+"href='mailto:{support_email}'>our OER support</a>,\n"
 "        after which an upload is possible."
 msgstr ""
-"Als Angehörige:r einer anderen Hochschule besuchen Sie die Informationsseite "
-"zur OER-Zertifizierung, um ein\n"
+"Als Angehörige:r einer anderen Hochschule besuchen Sie die "
+"Informationsseite zur OER-Zertifizierung, um ein\n"
 "        entsprechendes Angebot an Ihrer Hochschule zu finden bzw. "
-"übermitteln Sie Ihr Zertifikat  „OER Practitioner |\n"
-"        OER-Praktiker:in“ von fnma an <a href=\"mailto:telucation@tugraz."
-"at\">telucation@tugraz.at</a>, danach ist ein Upload möglich.."
+"übermitteln Sie Ihr Zertifikat  „OER Practitioner | OER-Praktiker:in“ von"
+" fnma an <a href='mailto:{support_email}'>unseren OER Support</a>, danach"
+" ist ein Upload möglich."
 
-#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:63
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:67
+#, python-brace-format
 msgid ""
 "For further information, please contact the OU Educational Technology "
-"directly at +43(316)873-8577 or write an email to <a href=\"mailto:"
-"telucation@tugraz.at\">telucation@tugraz.at</a>."
+"directly at {support_number} \n"
+"        or write an email to <a href='mailto:{support_email}'>our OER "
+"support</a>."
 msgstr ""
 "Für weitere Informationen wenden Sie sich direkt an die OE Lehr- und "
-"Lerntechnologien unter der Telefonnummer:\n"
-"        +43(316)873-8577 oder E-Mail-Adresse <a href=\"mailto:"
-"telucation@tugraz.at\">telucation@tugraz.at</a>."
+"Lerntechnologien unter der Telefonnummer: {support_number} \n"
+"        oder per E-Mail an <a href='mailto:{support_email}'>unseren OER "
+"Support</a>."
 
 #: invenio_records_lom/templates/invenio_records_lom/record.html:26
 msgid "Back-navigation"
@@ -245,20 +307,24 @@ msgstr "Beschreibung"
 msgid "Record Management"
 msgstr ""
 
-#: invenio_records_lom/templates/invenio_records_lom/record.html:156
+#: invenio_records_lom/templates/invenio_records_lom/record.html:159
 msgid "Original Content"
 msgstr "Quelle"
 
-#: invenio_records_lom/templates/invenio_records_lom/record.html:164
+#: invenio_records_lom/templates/invenio_records_lom/record.html:167
 msgid "Is Part of Courses"
 msgstr "Ist Teil der Kurse"
 
-#: invenio_records_lom/templates/invenio_records_lom/record.html:174
+#: invenio_records_lom/templates/invenio_records_lom/record.html:177
 msgid "Classifications"
 msgstr "Klassifikationen"
 
-#: invenio_records_lom/templates/invenio_records_lom/record.html:190
-#: invenio_records_lom/templates/invenio_records_lom/record.html:191
+#: invenio_records_lom/templates/invenio_records_lom/record.html:194
+msgid "Citation"
+msgstr "Referenzierung"
+
+#: invenio_records_lom/templates/invenio_records_lom/record.html:208
+#: invenio_records_lom/templates/invenio_records_lom/record.html:209
 msgid "Export"
 msgstr "Export"
 
@@ -287,30 +353,50 @@ msgid "Back to details"
 msgstr "Zurück zu den Details"
 
 #: invenio_records_lom/templates/invenio_records_lom/records/files.html:22
-#: invenio_records_lom/templates/invenio_records_lom/records/files.html:25
-#: invenio_records_lom/templates/invenio_records_lom/records/files.html:37
-#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:118
+#: invenio_records_lom/templates/invenio_records_lom/records/files.html:27
+#: invenio_records_lom/templates/invenio_records_lom/records/files.html:39
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:124
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:125
 msgid "Files"
 msgstr "Dateien"
 
-#: invenio_records_lom/templates/invenio_records_lom/records/files.html:45
-#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:133
+#: invenio_records_lom/templates/invenio_records_lom/records/files.html:47
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:140
 msgid "Reason"
 msgstr "Reason"
+
+#: invenio_records_lom/templates/invenio_records_lom/records/helpers/statistics.html:18
+#, fuzzy
+msgid "Views"
+msgstr "Vorschau"
+
+#: invenio_records_lom/templates/invenio_records_lom/records/helpers/statistics.html:28
+#, fuzzy
+msgid "Downloads"
+msgstr "Download"
+
+#: invenio_records_lom/templates/invenio_records_lom/records/helpers/statistics.html:37
+msgid "More info on how stats are collected..."
+msgstr ""
 
 #: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:39
 msgid "File preview"
 msgstr "Dateivorschau"
 
-#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:64
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:61
 msgid "Name"
 msgstr "Name"
 
-#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:65
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:62
 msgid "Size"
 msgstr "Größe"
 
-#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:87
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:67
+#, fuzzy
+msgid "Download all"
+msgstr "Alle Downloaden"
+
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:96
 msgid ""
 "This is the file fingerprint (checksum), which can be used to verify the "
 "file integrity."
@@ -318,26 +404,195 @@ msgstr ""
 "Das ist die Prüfsumme der Datei, die dafür verwendet werden kann die "
 "Dateiintegrität zu prüfen."
 
-#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:98
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:106
 msgid "Preview"
 msgstr "Vorschau"
 
-#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:103
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:110
 msgid "Download"
 msgstr "Download"
 
-#: invenio_records_lom/ui/records/__init__.py:100
-msgid "Educational Resources"
-msgstr "Bildungsinhalte"
+# | msgid ""
+# | "Open Educational Resources (OER) are open educational materials, i.e. "
+# | "teaching and learning materials that\n"
+# | "        are freely accessible and, thanks to appropriate licensing (or "
+# | "because they are in the public domain), may be\n"
+# | "        edited, further developed and distributed without additional "
+# | "permission."
+#~ msgid ""
+#~ "\"Open Educational Resources (OER) are "
+#~ "open educational materials, i.e. teaching "
+#~ "and learning materials that\n"
+#~ "        are freely accessible and, "
+#~ "thanks to appropriate licensing (or "
+#~ "because they are in the public "
+#~ "domain), may be\n"
+#~ "        edited, further developed and "
+#~ "distributed without additional permission.\""
+#~ msgstr ""
+#~ "\"Open Educational Resources (OER) sind "
+#~ "freie Bildungsmaterialien, d.h. Lehr- und "
+#~ "Lernmaterialien,\n"
+#~ "        die frei zugänglich sind und "
+#~ "dank entsprechender Lizenzierung (oder weil"
+#~ " sie gemeinfrei sind) ohne\n"
+#~ "        zusätzliche Erlaubnis bearbeitet, "
+#~ "weiterentwickelt und weitergegeben werden "
+#~ "dürfen.\""
 
-#~ msgid "Type query then press enter for search"
-#~ msgstr "Geben Sie ihre Suchanfrage ein"
+#~ msgid "Bündnis Freie Bildung, 2015"
+#~ msgstr "Bündnis Freie Bildung, 2015"
 
-#, fuzzy
-#~ msgid "General Information"
-#~ msgstr "Allgemeine Informationen"
+#~ msgid "Permission required!"
+#~ msgstr "Freigabe erforderlich!"
 
-#, fuzzy
-#~| msgid "Educational Informations"
-#~ msgid "Educational Information"
-#~ msgstr "Lernziele"
+#~ msgid ""
+#~ "Here you can upload your openly "
+#~ "licensed teaching and learning materials "
+#~ "(Open Educational Resources, OER for\n"
+#~ "        short). By doing this, you "
+#~ "can archive them sustainably and make"
+#~ " them publicly accessible and usable "
+#~ "to others.\n"
+#~ "        Furthermore, all open educational "
+#~ "resources uploaded here are automatically "
+#~ "transferred to <a href=\"oerhub.at\">OERhub.at</a>"
+#~ " - a\n"
+#~ "        national search engine for OER"
+#~ " - in order to reach an even"
+#~ " greater audience reach."
+#~ msgstr ""
+#~ "Hier können Sie Ihre offen lizenzierten"
+#~ " Lehr- und Lernmaterialien (Open "
+#~ "Educational Resources, kurz OER)\n"
+#~ "        hochladen und sie damit "
+#~ "einerseits nachhaltig archivieren und "
+#~ "anderseits öffentlich zugänglich und nutzbar"
+#~ " machen.\n"
+#~ "        Weiters werden die hier "
+#~ "hochgeladenen offenen Bildungsressourcen automatisch"
+#~ " an den <a href=\"oerhub.at\">OERhub.at</a> "
+#~ "- eine nationale Suchmaschine für OER"
+#~ " -\n"
+#~ "        übertragen, um eine noch größere Reichweite zu erzielen."
+
+#~ msgid ""
+#~ "To use the upload feature, have "
+#~ "your account activated by sending your"
+#~ " OER certificate issued by the "
+#~ "national\n"
+#~ "        certification body to <a "
+#~ "href=\"mailto:telucation@tugraz.at\">telucation@tugraz.at</a>."
+#~ msgstr ""
+#~ "Um die Upload-Funktion nutzen zu "
+#~ "können, lassen Sie sich freischalten, "
+#~ "indem Sie Ihr OER-Zertifikat „OER "
+#~ "Practitioner\n"
+#~ "        | OER-Praktiker:in“ der "
+#~ "nationalen Zertifizierungsstelle an <a "
+#~ "href=\"mailto:telucation@tugraz.at\">telucation@tugraz.at</a>\n"
+#~ "        schicken."
+
+# | msgid ""
+# | "Not yet certified? Members of Graz University of Technology are required
+# "
+# | "to obtain the OER certificate from\n"
+# | "        fnma at Graz University of Technology, which you can obatin as "
+# | "part of the in-house training. Please register\n"
+# | "        via your business card in <a href=\"online.tugraz."
+# | "at\">TUGRAZonline</a>."
+#~ msgid ""
+#~ "Not yet certified? Members of Graz "
+#~ "University of Technology are required to"
+#~ " obtain the OER certificate from\n"
+#~ "        fnma at Graz University of "
+#~ "Technology, which you can obtain as "
+#~ "part of the in-house training. "
+#~ "Please register\n"
+#~ "        via your business card in "
+#~ "<a href=\"online.tugraz.at\">TUGRAZonline</a>."
+#~ msgstr ""
+#~ "Noch nicht zertifiziert? Angehörige der "
+#~ "TU Graz können das Zertifikat durch "
+#~ "Teilnahme bei der der internen\n"
+#~ "        Weiterbildung  OER-Zertifikats von "
+#~ "fnma bei der TU Graz  erlangen. "
+#~ "Bitte melden Sie sich über Ihre "
+#~ "Visitenkarte im\n"
+#~ "        TUGRAZonline dazu an."
+
+#~ msgid ""
+#~ "As a member of another university, "
+#~ "visit the information page on OER "
+#~ "certification to find a corresponding\n"
+#~ "        offer at your university and "
+#~ "submit your certificate to <a "
+#~ "href=\"mailto:telucation@tugraz.at\">telucation@tugraz.at</a>,\n"
+#~ "        after which an upload is possible."
+#~ msgstr ""
+#~ "Als Angehörige:r einer anderen Hochschule "
+#~ "besuchen Sie die Informationsseite zur "
+#~ "OER-Zertifizierung, um ein\n"
+#~ "        entsprechendes Angebot an Ihrer "
+#~ "Hochschule zu finden bzw. übermitteln "
+#~ "Sie Ihr Zertifikat  „OER Practitioner |"
+#~ "\n"
+#~ "        OER-Praktiker:in“ von fnma an"
+#~ " <a "
+#~ "href=\"mailto:telucation@tugraz.at\">telucation@tugraz.at</a>, "
+#~ "danach ist ein Upload möglich.."
+
+#~ msgid ""
+#~ "For further information, please contact "
+#~ "the OU Educational Technology directly "
+#~ "at +43(316)873-8577 or write an email"
+#~ " to <a "
+#~ "href=\"mailto:telucation@tugraz.at\">telucation@tugraz.at</a>."
+#~ msgstr ""
+#~ "Für weitere Informationen wenden Sie "
+#~ "sich direkt an die OE Lehr- und"
+#~ " Lerntechnologien unter der Telefonnummer:\n"
+#~ ""
+#~ "        +43(316)873-8577 oder E-Mail-Adresse"
+#~ " <a "
+#~ "href=\"mailto:telucation@tugraz.at\">telucation@tugraz.at</a>."
+
+#~ msgid ""
+#~ "Not yet certified? Members of "
+#~ "{host_institute} are required to obtain "
+#~ "the OER certificate from\n"
+#~ "        fnma at {host_institute}, which "
+#~ "you can obtain as part of the "
+#~ "in-house training. Please register\n"
+#~ "        via your business card in "
+#~ "<a href={campus_url}>{host_campus}</a>."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Here you can upload your openly "
+#~ "licensed teaching and learning materials "
+#~ "(Open Educational Resources, OER for\n"
+#~ "        short). By doing this, you "
+#~ "can archive them sustainably and make"
+#~ " them publicly accessible and usable "
+#~ "to others.\n"
+#~ "        Furthermore, all open educational "
+#~ "resources uploaded here are automatically "
+#~ "transferred to <a href='oerhub.at'>OERhub.at</a> "
+#~ "- a\n"
+#~ "        national search engine for OER"
+#~ " - in order to reach an even"
+#~ " greater audience reach."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Not yet certified? Members of "
+#~ "{host_institute} are required to obtain "
+#~ "the OER certificate from\n"
+#~ "        fnma at {host_institute}, which "
+#~ "you can obtain as part of the "
+#~ "in-house training. Please register\n"
+#~ "        via your business card in "
+#~ "<a href='{campus_url}'>{host_campus}</a>."
+#~ msgstr ""
+

--- a/invenio_records_lom/translations/en/LC_MESSAGES/messages.po
+++ b/invenio_records_lom/translations/en/LC_MESSAGES/messages.po
@@ -1,84 +1,368 @@
-# Translations template for invenio_records_lom.
+# English (United States) translations for invenio_records_lom.
 # Copyright (C) 2022 Graz University of Technology
+# Copyright (C) 2026 BOKU University
 # This file is distributed under the same license as the invenio_records_lom
 # project.
-#  <christoph.ladurner@tugraz.at>, 2022.
+# <christoph.ladurner@tugraz.at>, 2022.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio_records_lom 0.1.0\n"
 "Report-Msgid-Bugs-To: info@tugraz.at\n"
-"POT-Creation-Date: 2022-03-25 13:22+0100\n"
+"POT-Creation-Date: 2026-04-15 09:26+0200\n"
 "PO-Revision-Date: 2022-03-25 13:31+0100\n"
-"Last-Translator:  <christoph.ladurner@tugraz.at>\n"
-"Language-Team: English\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Last-Translator: <christoph.ladurner@tugraz.at>\n"
 "Language: en_US\n"
+"Language-Team: English\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
-#: invenio_records_lom/config.py:27
+#: invenio_records_lom/config.py:49
+msgid "Best match"
+msgstr ""
+
+#: invenio_records_lom/config.py:53
+msgid "Newest"
+msgstr ""
+
+#: invenio_records_lom/config.py:57
+msgid "Most viewed"
+msgstr ""
+
+#: invenio_records_lom/config.py:61
+#, fuzzy
+msgid "Most downloaded"
+msgstr "Download"
+
+#: invenio_records_lom/config.py:105
 msgid "JSON"
 msgstr "JSON"
 
-#: invenio_records_lom/config.py:53 invenio_records_lom/config.py:60
-#: invenio_records_lom/config.py:84
+#: invenio_records_lom/config.py:137 invenio_records_lom/config.py:144
+#: invenio_records_lom/config.py:168
+#: invenio_records_lom/templates/invenio_records_lom/record.html:187
 msgid "DOI"
 msgstr "DOI"
 
-#: invenio_records_lom/config.py:65
+#: invenio_records_lom/config.py:149
 msgid "OAI ID"
 msgstr "OAI ID"
 
-#: invenio_records_lom/config.py:91
+#: invenio_records_lom/config.py:175
 msgid "OAI"
 msgstr "OAI"
 
-#: invenio_records_lom/services/schemas/records.py:23
+#: invenio_records_lom/config.py:396
+msgid "APA"
+msgstr ""
+
+#: invenio_records_lom/config.py:397
+msgid "Chicago"
+msgstr ""
+
+#: invenio_records_lom/config.py:398
+msgid "IEEE"
+msgstr ""
+
+#: invenio_records_lom/config.py:399
+msgid "Harvard"
+msgstr ""
+
+#: invenio_records_lom/config.py:400
+msgid "MLA"
+msgstr ""
+
+#: invenio_records_lom/config.py:401
+msgid "Vancouver"
+msgstr ""
+
+#: invenio_records_lom/ext.py:163
+#, fuzzy
+msgid "Educational Resources"
+msgstr "Educational Information"
+
+#: invenio_records_lom/services/facets.py:23
+msgid "CC0 1.0"
+msgstr ""
+
+#: invenio_records_lom/services/facets.py:24
+msgid "CC BY 4.0"
+msgstr ""
+
+#: invenio_records_lom/services/facets.py:25
+msgid "CC BY-SA 4.0"
+msgstr ""
+
+#: invenio_records_lom/services/facets.py:26
+msgid "CC BY-ND 4.0"
+msgstr ""
+
+#: invenio_records_lom/services/facets.py:27
+msgid "CC BY-NC 4.0"
+msgstr ""
+
+#: invenio_records_lom/services/facets.py:28
+msgid "CC BY-NC-SA 4.0"
+msgstr ""
+
+#: invenio_records_lom/services/facets.py:29
+msgid "CC BY-NC-ND 4.0"
+msgstr ""
+
+#: invenio_records_lom/services/facets.py:46
+msgid "License"
+msgstr ""
+
+#: invenio_records_lom/services/pids.py:68
+msgid "Missing publisher."
+msgstr ""
+
+#: invenio_records_lom/services/schemas/metadata.py:64
+#: invenio_records_lom/services/schemas/metadata.py:319
+#: invenio_records_lom/services/schemas/metadata.py:348
+#: invenio_records_lom/services/schemas/metadata.py:392
+msgid "Missing data for required field."
+msgstr ""
+
+#: invenio_records_lom/services/schemas/metadata.py:250
+msgid "Name cannot be empty."
+msgstr ""
+
+#: invenio_records_lom/services/schemas/metadata.py:293
+msgid "Must provide at least one author and one publisher."
+msgstr ""
+
+#: invenio_records_lom/services/schemas/metadata.py:296
+msgid "Must provide at least one author."
+msgstr ""
+
+#: invenio_records_lom/services/schemas/metadata.py:299
+msgid "Must provide at least one publisher."
+msgstr ""
+
+#: invenio_records_lom/services/schemas/metadata.py:403
+msgid "Not a valid OEFOS-url."
+msgstr ""
+
+#: invenio_records_lom/services/schemas/metadata.py:447
+msgid "Must add at least one OEFOS."
+msgstr ""
+
+#: invenio_records_lom/services/schemas/records.py:33
 msgid "Persistent identifier scheme unknown to LOM."
 msgstr "Persistent identifier scheme unknown to LOM."
 
-#: invenio_records_lom/templates/invenio_records_lom/record.html:56
-msgid "General Informations"
-msgstr "General Informations"
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:13
+#: invenio_records_lom/templates/invenio_records_lom/uploads.html:14
+msgid "OER Uploads"
+msgstr ""
 
-#: invenio_records_lom/templates/invenio_records_lom/record.html:65
-msgid "Educational Informations"
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:27
+#, fuzzy
+msgid "Open Educational Resources"
 msgstr "Educational Informations"
 
-#: invenio_records_lom/templates/invenio_records_lom/record.html:96
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:30
+msgid ""
+"\"Open Educational Resources (OER) are open educational materials, i.e. "
+"teaching and learning materials that\n"
+"        are freely accessible and, thanks to appropriate licensing (or "
+"because they are in the public domain), may be\n"
+"        edited, further developed and distributed without additional "
+"permission.\""
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:35
+msgid "Bündnis Freie Bildung, 2015"
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:37
+msgid "Permission required!"
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:40
+msgid ""
+"Here you can upload your openly licensed teaching and learning materials "
+"(Open Educational Resources, OER for\n"
+"        short). By doing this, you can archive them sustainably and make "
+"them publicly accessible and usable to others.\n"
+"        Furthermore, all open educational resources uploaded here are "
+"automatically transferred to <a "
+"href='https://www.oerhub.at'>OERhub.at</a> - a\n"
+"        national search engine for OER - in order to reach an even "
+"greater audience reach."
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:47
+#, python-brace-format
+msgid ""
+"To use the upload feature, have your account activated by sending your "
+"OER certificate issued by the national \n"
+"        certification body to <a href='mailto:{support_email}'>our OER "
+"support</a>."
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:53
+#, python-brace-format
+msgid ""
+"Not yet certified? Members of {host_institute} are required to obtain the"
+" OER certificate from\n"
+"        fnma at {host_institute}, which you can obtain as part of the in-"
+"house training. Please register\n"
+"        via your business card in <a "
+"href='{campus_url}'>{host_campus}</a>."
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:60
+#, python-brace-format
+msgid ""
+"As a member of another university, visit the information page on OER "
+"certification to find a corresponding\n"
+"        offer at your university and submit your certificate to <a "
+"href='mailto:{support_email}'>our OER support</a>,\n"
+"        after which an upload is possible."
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:67
+#, python-brace-format
+msgid ""
+"For further information, please contact the OU Educational Technology "
+"directly at {support_number} \n"
+"        or write an email to <a href='mailto:{support_email}'>our OER "
+"support</a>."
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/record.html:26
+msgid "Back-navigation"
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/record.html:28
+#, fuzzy
+msgid "Back to edit"
+msgstr "Back to details"
+
+#: invenio_records_lom/templates/invenio_records_lom/record.html:38
+msgid "Labels for version, resource-type, access-status"
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/record.html:56
+msgid "Resource type"
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/record.html:59
+msgid "Access status"
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/record.html:77
+msgid "Record title and creators"
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/record.html:79
+msgid "Contributors"
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/record.html:94
+msgid "Record Description"
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/record.html:95
+msgid "Description"
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/record.html:131
+msgid "Record Management"
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/record.html:159
 msgid "Original Content"
 msgstr "Original Content"
 
-#: invenio_records_lom/templates/invenio_records_lom/record.html:106
+#: invenio_records_lom/templates/invenio_records_lom/record.html:167
+msgid "Is Part of Courses"
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/record.html:177
+msgid "Classifications"
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/record.html:194
+msgid "Citation"
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/record.html:208
+#: invenio_records_lom/templates/invenio_records_lom/record.html:209
 msgid "Export"
 msgstr "Export"
+
+#: invenio_records_lom/templates/invenio_records_lom/search.html:9
+msgid "OER Search Results"
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/uploads.html:29
+msgid "New upload"
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/records/deposit.html:12
+msgid "New Version of OER Upload"
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/records/deposit.html:14
+msgid "New OER Upload"
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/records/deposit.html:16
+msgid "Edit OER Upload"
+msgstr ""
 
 #: invenio_records_lom/templates/invenio_records_lom/records/export.html:26
 msgid "Back to details"
 msgstr "Back to details"
 
-#: invenio_records_lom/templates/invenio_records_lom/records/files.html:35
-#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:108
+#: invenio_records_lom/templates/invenio_records_lom/records/files.html:22
+#: invenio_records_lom/templates/invenio_records_lom/records/files.html:27
+#: invenio_records_lom/templates/invenio_records_lom/records/files.html:39
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:124
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:125
 msgid "Files"
 msgstr "Files"
 
-#: invenio_records_lom/templates/invenio_records_lom/records/files.html:43
-#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:118
+#: invenio_records_lom/templates/invenio_records_lom/records/files.html:47
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:140
 msgid "Reason"
 msgstr "Reason"
 
-#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:57
+#: invenio_records_lom/templates/invenio_records_lom/records/helpers/statistics.html:18
+msgid "Views"
+msgstr "Views"
+
+#: invenio_records_lom/templates/invenio_records_lom/records/helpers/statistics.html:28
+msgid "Downloads"
+msgstr "Downloads"
+
+#: invenio_records_lom/templates/invenio_records_lom/records/helpers/statistics.html:37
+msgid "More info on how stats are collected..."
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:39
+msgid "File preview"
+msgstr "Preview"
+
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:61
 msgid "Name"
 msgstr "Name"
 
-#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:58
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:62
 msgid "Size"
 msgstr "Size"
 
-#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:78
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:67
+msgid "Download all"
+msgstr "Download all files"
+
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:96
 msgid ""
 "This is the file fingerprint (checksum), which can be used to verify the "
 "file integrity."
@@ -86,10 +370,11 @@ msgstr ""
 "This is the file fingerprint (checksum), which can be used to verify the "
 "file integrity."
 
-#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:88
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:106
 msgid "Preview"
 msgstr "Preview"
 
-#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:93
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:110
 msgid "Download"
 msgstr "Download"
+

--- a/invenio_records_lom/translations/messages.pot
+++ b/invenio_records_lom/translations/messages.pot
@@ -1,95 +1,166 @@
 # Translations template for invenio-records-lom.
-# Copyright (C) 2023 Graz University of Technology
+# Copyright (C) 2026 Graz University of Technology
 # This file is distributed under the same license as the invenio-records-lom
 # project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: invenio-records-lom 0.12.1\n"
+"Project-Id-Version: invenio-records-lom 0.20.1\n"
 "Report-Msgid-Bugs-To: info@tugraz.at\n"
-"POT-Creation-Date: 2023-12-06 11:08+0100\n"
+"POT-Creation-Date: 2026-04-15 09:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.18.0\n"
 
-#: invenio_records_lom/config.py:42
+#: invenio_records_lom/config.py:49
 msgid "Best match"
 msgstr ""
 
-#: invenio_records_lom/config.py:46
+#: invenio_records_lom/config.py:53
 msgid "Newest"
 msgstr ""
 
-#: invenio_records_lom/config.py:85
+#: invenio_records_lom/config.py:57
+msgid "Most viewed"
+msgstr ""
+
+#: invenio_records_lom/config.py:61
+msgid "Most downloaded"
+msgstr ""
+
+#: invenio_records_lom/config.py:105
 msgid "JSON"
 msgstr ""
 
-#: invenio_records_lom/config.py:117 invenio_records_lom/config.py:124
-#: invenio_records_lom/config.py:148
-#: invenio_records_lom/templates/invenio_records_lom/record.html:184
+#: invenio_records_lom/config.py:137 invenio_records_lom/config.py:144
+#: invenio_records_lom/config.py:168
+#: invenio_records_lom/templates/invenio_records_lom/record.html:187
 msgid "DOI"
 msgstr ""
 
-#: invenio_records_lom/config.py:129
+#: invenio_records_lom/config.py:149
 msgid "OAI ID"
 msgstr ""
 
-#: invenio_records_lom/config.py:155
+#: invenio_records_lom/config.py:175
 msgid "OAI"
 msgstr ""
 
-#: invenio_records_lom/services/facets.py:22
-msgid "CC BY 4.0"
+#: invenio_records_lom/config.py:396
+msgid "APA"
+msgstr ""
+
+#: invenio_records_lom/config.py:397
+msgid "Chicago"
+msgstr ""
+
+#: invenio_records_lom/config.py:398
+msgid "IEEE"
+msgstr ""
+
+#: invenio_records_lom/config.py:399
+msgid "Harvard"
+msgstr ""
+
+#: invenio_records_lom/config.py:400
+msgid "MLA"
+msgstr ""
+
+#: invenio_records_lom/config.py:401
+msgid "Vancouver"
+msgstr ""
+
+#: invenio_records_lom/ext.py:163
+msgid "Educational Resources"
 msgstr ""
 
 #: invenio_records_lom/services/facets.py:23
-msgid "CC BY-SA 4.0"
+msgid "CC0 1.0"
 msgstr ""
 
 #: invenio_records_lom/services/facets.py:24
-msgid "CC BY-ND 4.0"
+msgid "CC BY 4.0"
 msgstr ""
 
 #: invenio_records_lom/services/facets.py:25
-msgid "CC BY-NC 4.0"
+msgid "CC BY-SA 4.0"
 msgstr ""
 
 #: invenio_records_lom/services/facets.py:26
-msgid "CC BY-NC-SA 4.0"
+msgid "CC BY-ND 4.0"
 msgstr ""
 
 #: invenio_records_lom/services/facets.py:27
+msgid "CC BY-NC 4.0"
+msgstr ""
+
+#: invenio_records_lom/services/facets.py:28
+msgid "CC BY-NC-SA 4.0"
+msgstr ""
+
+#: invenio_records_lom/services/facets.py:29
 msgid "CC BY-NC-ND 4.0"
 msgstr ""
 
-#: invenio_records_lom/services/facets.py:44
+#: invenio_records_lom/services/facets.py:46
 msgid "License"
 msgstr ""
 
-#: invenio_records_lom/services/pids.py:52
+#: invenio_records_lom/services/pids.py:68
 msgid "Missing publisher."
+msgstr ""
+
+#: invenio_records_lom/services/schemas/metadata.py:64
+#: invenio_records_lom/services/schemas/metadata.py:319
+#: invenio_records_lom/services/schemas/metadata.py:348
+#: invenio_records_lom/services/schemas/metadata.py:392
+msgid "Missing data for required field."
+msgstr ""
+
+#: invenio_records_lom/services/schemas/metadata.py:250
+msgid "Name cannot be empty."
+msgstr ""
+
+#: invenio_records_lom/services/schemas/metadata.py:293
+msgid "Must provide at least one author and one publisher."
+msgstr ""
+
+#: invenio_records_lom/services/schemas/metadata.py:296
+msgid "Must provide at least one author."
+msgstr ""
+
+#: invenio_records_lom/services/schemas/metadata.py:299
+msgid "Must provide at least one publisher."
+msgstr ""
+
+#: invenio_records_lom/services/schemas/metadata.py:403
+msgid "Not a valid OEFOS-url."
+msgstr ""
+
+#: invenio_records_lom/services/schemas/metadata.py:447
+msgid "Must add at least one OEFOS."
 msgstr ""
 
 #: invenio_records_lom/services/schemas/records.py:33
 msgid "Persistent identifier scheme unknown to LOM."
 msgstr ""
 
-#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:12
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:13
 #: invenio_records_lom/templates/invenio_records_lom/uploads.html:14
 msgid "OER Uploads"
 msgstr ""
 
-#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:26
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:27
 msgid "Open Educational Resources"
 msgstr ""
 
-#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:29
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:30
 msgid ""
 "\"Open Educational Resources (OER) are open educational materials, i.e. "
 "teaching and learning materials that\n"
@@ -99,58 +170,64 @@ msgid ""
 "permission.\""
 msgstr ""
 
-#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:34
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:35
 msgid "Bündnis Freie Bildung, 2015"
 msgstr ""
 
-#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:36
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:37
 msgid "Permission required!"
 msgstr ""
 
-#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:39
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:40
 msgid ""
 "Here you can upload your openly licensed teaching and learning materials "
 "(Open Educational Resources, OER for\n"
 "        short). By doing this, you can archive them sustainably and make "
 "them publicly accessible and usable to others.\n"
 "        Furthermore, all open educational resources uploaded here are "
-"automatically transferred to <a href=\"oerhub.at\">OERhub.at</a> - a\n"
+"automatically transferred to <a "
+"href='https://www.oerhub.at'>OERhub.at</a> - a\n"
 "        national search engine for OER - in order to reach an even "
 "greater audience reach."
 msgstr ""
 
-#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:46
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:47
+#, python-brace-format
 msgid ""
 "To use the upload feature, have your account activated by sending your "
-"OER certificate issued by the national\n"
-"        certification body to <a "
-"href=\"mailto:telucation@tugraz.at\">telucation@tugraz.at</a>."
+"OER certificate issued by the national \n"
+"        certification body to <a href='mailto:{support_email}'>our OER "
+"support</a>."
 msgstr ""
 
-#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:51
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:53
+#, python-brace-format
 msgid ""
-"Not yet certified? Members of Graz University of Technology are required "
-"to obtain the OER certificate from\n"
-"        fnma at Graz University of Technology, which you can obtain as "
-"part of the in-house training. Please register\n"
+"Not yet certified? Members of {host_institute} are required to obtain the"
+" OER certificate from\n"
+"        fnma at {host_institute}, which you can obtain as part of the in-"
+"house training. Please register\n"
 "        via your business card in <a "
-"href=\"online.tugraz.at\">TUGRAZonline</a>."
+"href='{campus_url}'>{host_campus}</a>."
 msgstr ""
 
-#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:57
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:60
+#, python-brace-format
 msgid ""
 "As a member of another university, visit the information page on OER "
 "certification to find a corresponding\n"
 "        offer at your university and submit your certificate to <a "
-"href=\"mailto:telucation@tugraz.at\">telucation@tugraz.at</a>,\n"
+"href='mailto:{support_email}'>our OER support</a>,\n"
 "        after which an upload is possible."
 msgstr ""
 
-#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:63
+#: invenio_records_lom/templates/invenio_records_lom/not_licensed_text.html:67
+#, python-brace-format
 msgid ""
 "For further information, please contact the OU Educational Technology "
-"directly at +43(316)873-8577 or write an email to <a "
-"href=\"mailto:telucation@tugraz.at\">telucation@tugraz.at</a>."
+"directly at {support_number} \n"
+"        or write an email to <a href='mailto:{support_email}'>our OER "
+"support</a>."
 msgstr ""
 
 #: invenio_records_lom/templates/invenio_records_lom/record.html:26
@@ -193,20 +270,24 @@ msgstr ""
 msgid "Record Management"
 msgstr ""
 
-#: invenio_records_lom/templates/invenio_records_lom/record.html:156
+#: invenio_records_lom/templates/invenio_records_lom/record.html:159
 msgid "Original Content"
 msgstr ""
 
-#: invenio_records_lom/templates/invenio_records_lom/record.html:164
+#: invenio_records_lom/templates/invenio_records_lom/record.html:167
 msgid "Is Part of Courses"
 msgstr ""
 
-#: invenio_records_lom/templates/invenio_records_lom/record.html:174
+#: invenio_records_lom/templates/invenio_records_lom/record.html:177
 msgid "Classifications"
 msgstr ""
 
-#: invenio_records_lom/templates/invenio_records_lom/record.html:190
-#: invenio_records_lom/templates/invenio_records_lom/record.html:191
+#: invenio_records_lom/templates/invenio_records_lom/record.html:194
+msgid "Citation"
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/record.html:208
+#: invenio_records_lom/templates/invenio_records_lom/record.html:209
 msgid "Export"
 msgstr ""
 
@@ -235,44 +316,57 @@ msgid "Back to details"
 msgstr ""
 
 #: invenio_records_lom/templates/invenio_records_lom/records/files.html:22
-#: invenio_records_lom/templates/invenio_records_lom/records/files.html:25
-#: invenio_records_lom/templates/invenio_records_lom/records/files.html:37
-#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:118
+#: invenio_records_lom/templates/invenio_records_lom/records/files.html:27
+#: invenio_records_lom/templates/invenio_records_lom/records/files.html:39
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:124
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:125
 msgid "Files"
 msgstr ""
 
-#: invenio_records_lom/templates/invenio_records_lom/records/files.html:45
-#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:133
+#: invenio_records_lom/templates/invenio_records_lom/records/files.html:47
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:140
 msgid "Reason"
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/records/helpers/statistics.html:18
+msgid "Views"
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/records/helpers/statistics.html:28
+msgid "Downloads"
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/records/helpers/statistics.html:37
+msgid "More info on how stats are collected..."
 msgstr ""
 
 #: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:39
 msgid "File preview"
 msgstr ""
 
-#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:64
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:61
 msgid "Name"
 msgstr ""
 
-#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:65
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:62
 msgid "Size"
 msgstr ""
 
-#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:87
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:67
+msgid "Download all"
+msgstr ""
+
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:96
 msgid ""
 "This is the file fingerprint (checksum), which can be used to verify the "
 "file integrity."
 msgstr ""
 
-#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:98
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:106
 msgid "Preview"
 msgstr ""
 
-#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:103
+#: invenio_records_lom/templates/invenio_records_lom/records/macros/files.html:110
 msgid "Download"
-msgstr ""
-
-#: invenio_records_lom/ui/records/__init__.py:100
-msgid "Educational Resources"
 msgstr ""
 

--- a/invenio_records_lom/utils/metadata.py
+++ b/invenio_records_lom/utils/metadata.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2022-2025 Graz University of Technology.
+# Copyright (C) 2025 BOKU University.
 #
 # invenio-records-lom is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.


### PR DESCRIPTION
This PR aims to make template not-licensed-text.html customizeable

Following issues are done here
   - replace hardcoded e-mail adress, phone number, university campus, and institution with variables
   - define variables in config.py
   - adapt message-ids to usage of variables