### PR TITLE
Add LOM Search navigation template config hook

### DIFF
--- a/invenio_records_lom/config.py
+++ b/invenio_records_lom/config.py
@@ -26,6 +26,13 @@ from .utils import build_record_unique_id
 
 LOM_BASE_TEMPLATE = "invenio_records_lom/base.html"
 
+LOM_SEARCH_NAV_TEMPLATE = None
+"""Template injected above the lom search app.
+
+Set to a template path to render a custom nav above the search results
+e.g. a resource type switcher. ``None`` disables the injection.
+"""
+
 #
 # Permission Configuration
 #

--- a/invenio_records_lom/templates/invenio_records_lom/search.html
+++ b/invenio_records_lom/templates/invenio_records_lom/search.html
@@ -1,6 +1,6 @@
 {# -*- coding: utf-8 -*-
 
-  Copyright (C) 2022-2023 Graz University of Technology.
+  Copyright (C) 2022-2026 Graz University of Technology.
 
   invenio-records-lom is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -18,6 +18,9 @@
 
 {%- block page_body %}
   <div class="ui container">
+    {%- if config.get('LOM_SEARCH_NAV_TEMPLATE') %}
+      {%- include config.LOM_SEARCH_NAV_TEMPLATE %}
+    {%- endif %}
     <div id="invenio-search-lom-config" data-invenio-search-config='{{ search_app_lom_config() | tojson }}'></div>
   </div>
 {%- endblock page_body %}


### PR DESCRIPTION
Adds LOM Search navigation template  to config.py and injects it above the search app in the search template. 
Allows deployments to render a custom nav for example for resource type switcher without overriding the entire search template.