### PR TITLE
Make the OER uploads dashboard overridable

### DIFF
--- a/invenio_records_lom/config.py
+++ b/invenio_records_lom/config.py
@@ -26,6 +26,9 @@ from .utils import build_record_unique_id
 
 LOM_BASE_TEMPLATE = "invenio_records_lom/base.html"
 
+LOM_UPLOADS_TEMPLATE = "invenio_records_lom/uploads.html"
+"""Template for the user's OER uploads dashboard."""
+
 LOM_SEARCH_NAV_TEMPLATE = None
 """Template injected above the lom search app.
 

--- a/invenio_records_lom/templates/invenio_records_lom/uploads.html
+++ b/invenio_records_lom/templates/invenio_records_lom/uploads.html
@@ -23,15 +23,18 @@
     {% include "invenio_app_rdm/users/header.html" %}
   {%- endblock user_dashboard_header %}
 
-  <div class="ui container rel-mt-2">
-    <a class="ui tiny button positive right floated labeled icon m-0" href="/oer/uploads/new" style="margin-top: 18px !important">
-      <i class="upload icon" aria-hidden="true"></i>
-      {{ _('New upload') }}
-    </a>
-  </div>
+  {%- block dashboard_actions %}
+    <div class="ui container rel-mt-2">
+      <a class="ui tiny button positive right floated labeled icon m-0" href="/oer/uploads/new" style="margin-top: 18px !important">
+        <i class="upload icon" aria-hidden="true"></i>
+        {{ _('New upload') }}
+      </a>
+    </div>
+  {%- endblock dashboard_actions %}
 
   <div class="ui container rel-mt-2">
     <div id="invenio-search-lom-config"
+         class="uploads-search-app"
          data-invenio-search-config='{{ search_app_lom_user_uploads_config() | tojson }}'>
     </div>
   </div>

--- a/invenio_records_lom/ui/records/deposits.py
+++ b/invenio_records_lom/ui/records/deposits.py
@@ -249,7 +249,7 @@ def uploads(*, is_oer_certified: bool = False) -> str:
     )["avatar"]
 
     if is_oer_certified:
-        template = "invenio_records_lom/uploads.html"
+        template = current_app.config["LOM_UPLOADS_TEMPLATE"]
     else:
         template = "invenio_records_lom/not_licensed_text.html"
 


### PR DESCRIPTION
 Same change as tu-graz-library/invenio-records-marc21#277, applied to lom.

The OER uploads dashboard is rendered from a hardcoded template path, so a deployment that wants to customise it different upload action, page description, layout has no clean way in

 This PR adds a LOM_UPLOADS_TEMPLATE config defaulting to the current template, so behaviour is unchanged and the view renders whatever it points at. The default template wraps its upload action in a dashboard actions block, so that template can extend it and override just that block instead of copying the whole file.